### PR TITLE
Updating getForces() to account for reference pressure

### DIFF
--- a/dafoam/pyDAFoam.py
+++ b/dafoam/pyDAFoam.py
@@ -309,6 +309,10 @@ class DAOPTION(object):
     ## and shows up in the constant/polyMesh/boundary file
     designSurfaces = ["None"]
 
+    ## Fluid-structure interatcion (FSI) options. This dictionary takes in the required values for
+    ## an FSI case to be used throughout the simulation.
+    fsi = {"pRef": 0.0}
+
     # *********************************************************************************************
     # ****************************** Intermediate Options *****************************************
     # *********************************************************************************************

--- a/src/adjoint/DASolver/DASolver.C
+++ b/src/adjoint/DASolver/DASolver.C
@@ -337,8 +337,8 @@ void DASolver::getForces(Vec fX, Vec fY, Vec fZ, Vec pointList)
 
 #ifndef SolidDASolver
     // Get reference pressure
-    scalarList p0;
-    daOptionPtr_->getAllOptions().subDict("primalBC").subDict("p0").readEntry<scalarList>("value", p0);
+    scalar pRef;
+    daOptionPtr_->getAllOptions().subDict("fsi").readEntry<scalar>("pRef", pRef);
 
     // Generate patches, point mesh, and point boundary mesh
     const polyBoundaryMesh& patches = meshPtr_->boundaryMesh();
@@ -412,7 +412,7 @@ void DASolver::getForces(Vec fX, Vec fY, Vec fZ, Vec pointList)
         // create a shorter handle for the boundary patch
         const fvPatch& patch = meshPtr_->boundary()[patchI];
         // normal force
-        vectorField fN(Sfb[patchI] * (p.boundaryField()[patchI] - p0[0]));
+        vectorField fN(Sfb[patchI] * (p.boundaryField()[patchI] - pRef));
         // tangential force
         vectorField fT(Sfb[patchI] & devRhoReffb[patchI]);
         // sum them up


### PR DESCRIPTION
This PR continues on PR #187 working towards implementing aerostructural optimization with DAFoam and TACS. This PR fixes an issue that caused the calculated forces to be overestimated as the reference pressure was not subtracted when computing force due to pressure. This PR also adds an options dictionary for FSI that we can use in the future if we need to add more parameters.

With this fix, the aerostructural analysis (MDA) of the MDO Lab MACH-aero tutorial wing converges.

Ran black and clang-format to format the code to be consistent with the rest of DAFoam.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

X Bugfix (non-breaking change which fixes an issue)
X New feature (non-breaking change which adds functionality)
- Breaking change (non-backwards-compatible fix or feature)
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Documentation update
- Other (please describe)

## Testing
I compiled the code locally on my machine and ran a DAFoam + TACS aerostructural analysis successfully.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
