### PR TITLE
Fix for getForces() function in parallel

### DIFF
--- a/dafoam/pyDAFoam.py
+++ b/dafoam/pyDAFoam.py
@@ -2372,36 +2372,41 @@ class PYDAFOAM(object):
             Forces on this processor. Note that N may be 0, and an
             empty array of shape (0, 3) can be returned.
         """
+        Info("Computing surface forces")
         # Calculate number of surface points
-        nPts, nCells = self._getSurfaceSize(self.allWallsGroup)
+        nPts, _ = self._getSurfaceSize(self.allWallsGroup)
 
         # Initialize PETSc vectors
         pointListTemp = PETSc.Vec().create(comm=PETSc.COMM_WORLD)
         pointListTemp.setSizes((nPts, PETSc.DECIDE), bsize=1)
         pointListTemp.setFromOptions()
+        pointListTemp.zeroEntries()
 
         fX = PETSc.Vec().create(comm=PETSc.COMM_WORLD)
         fX.setSizes((nPts, PETSc.DECIDE), bsize=1)
         fX.setFromOptions()
+        fX.zeroEntries()
 
         fY = PETSc.Vec().create(comm=PETSc.COMM_WORLD)
         fY.setSizes((nPts, PETSc.DECIDE), bsize=1)
         fY.setFromOptions()
+        fY.zeroEntries()
 
         fZ = PETSc.Vec().create(comm=PETSc.COMM_WORLD)
         fZ.setSizes((nPts, PETSc.DECIDE), bsize=1)
         fZ.setFromOptions()
+        fZ.zeroEntries()
 
         # Compute forces
         self.solver.getForces(fX, fY, fZ, pointListTemp)
 
         # Copy data from PETSc vectors
         forces = np.zeros((nPts, 3))
-        forces[:, 0] = np.copy(fX.getValues(range(0, nPts)))
-        forces[:, 1] = np.copy(fY.getValues(range(0, nPts)))
-        forces[:, 2] = np.copy(fZ.getValues(range(0, nPts)))
+        forces[:, 0] = np.copy(fX.getArray())
+        forces[:, 1] = np.copy(fY.getArray())
+        forces[:, 2] = np.copy(fZ.getArray())
 
-        pointList = np.copy(pointListTemp.getValues(range(0, nPts)))
+        pointList = np.copy(pointListTemp.getArray())
 
         # Cleanup PETSc vectors
         fX.destroy()

--- a/dafoam/pyDAFoam.py
+++ b/dafoam/pyDAFoam.py
@@ -2418,6 +2418,20 @@ class PYDAFOAM(object):
         indices = np.argsort(pointList)
         forces = forces[indices]
 
+        # Print total force
+        fXSum = np.sum(forces[:,0])
+        fYSum = np.sum(forces[:,1])
+        fZSum = np.sum(forces[:,2])
+
+        fXTot = self.comm.allreduce(fXSum, op=MPI.SUM)
+        fYTot = self.comm.allreduce(fYSum, op=MPI.SUM)
+        fZTot = self.comm.allreduce(fZSum, op=MPI.SUM)
+
+        Info("Total force:")
+        Info("Fx = %e" % fXTot)
+        Info("Fy = %e" % fYTot)
+        Info("Fz = %e" % fZTot)
+
         if groupName is None:
             groupName = self.allWallsGroup
 

--- a/dafoam/pyDAFoam.py
+++ b/dafoam/pyDAFoam.py
@@ -2419,9 +2419,9 @@ class PYDAFOAM(object):
         forces = forces[indices]
 
         # Print total force
-        fXSum = np.sum(forces[:,0])
-        fYSum = np.sum(forces[:,1])
-        fZSum = np.sum(forces[:,2])
+        fXSum = np.sum(forces[:, 0])
+        fYSum = np.sum(forces[:, 1])
+        fZSum = np.sum(forces[:, 2])
 
         fXTot = self.comm.allreduce(fXSum, op=MPI.SUM)
         fYTot = self.comm.allreduce(fYSum, op=MPI.SUM)

--- a/src/adjoint/DASolver/DASolver.C
+++ b/src/adjoint/DASolver/DASolver.C
@@ -327,14 +327,6 @@ void DASolver::getForces(Vec fX, Vec fY, Vec fZ, Vec pointList)
         forces : a (nPoint x 3) array of forces for all of the nodes
         of the desired patches.
     */
-    Info << "Calculating surface forces" << endl;
-    // Zero point force arrays
-    VecZeroEntries(fX);
-    VecZeroEntries(fY);
-    VecZeroEntries(fZ);
-
-    VecZeroEntries(pointList);
-
 #ifndef SolidDASolver
     // Get reference pressure
     scalar pRef;
@@ -375,8 +367,6 @@ void DASolver::getForces(Vec fX, Vec fY, Vec fZ, Vec pointList)
         label patchIPoints = boundaryMesh.findPatchID(patchListSort[cI]);
         nPoints += boundaryMesh[patchIPoints].size();
     }
-
-    Info << "Total number of points: " << nPoints << endl;
 
     // Initialize surface field for face-centered forces
     volVectorField volumeForceField(
@@ -512,9 +502,8 @@ void DASolver::getForces(Vec fX, Vec fY, Vec fZ, Vec pointList)
     VecRestoreArray(fZ, &vecArrayFZ);
 
     VecRestoreArray(pointList, &vecArrayPointList);
-#endif
 
-    Info << "Calculating surface force.... Completed!" << endl;
+#endif
     return;
 }
 


### PR DESCRIPTION
## Purpose
This PR builds on PRs #187 and #193 to fix the `getForces()` function to run in parallel. This PR also adds a printout of the Fx, Fy, and Fz total forces over the entire surface used in the `getForces()` function. With these updates aerostructural analysis should now work in parallel.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

X Bugfix (non-breaking change which fixes an issue)
X New feature (non-breaking change which adds functionality)
- Breaking change (non-backwards-compatible fix or feature)
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Documentation update
- Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
