### PR TITLE
Addition of scalar point source and its inclusion into a new solver

### DIFF
--- a/dafoam/pyDAFoam.py
+++ b/dafoam/pyDAFoam.py
@@ -953,7 +953,7 @@ class PYDAFOAM(object):
         """
 
         self.solverRegistry = {
-            "Incompressible": ["DASimpleFoam", "DASimpleTFoam", "DAPisoFoam", "DAPimpleFoam", "DAPimpleDyMFoam"],
+            "Incompressible": ["DASimpleFoam", "DASimpleTFoam", "DAPisoFoam", "DAPimpleFoam", "DAPimpleDyMFoam", "DAMySimpleTFoam"],
             "Compressible": ["DARhoSimpleFoam", "DARhoSimpleCFoam", "DATurboFoam", "DARhoPimpleFoam"],
             "Solid": ["DASolidDisplacementFoam", "DALaplacianFoam", "DAHeatTransferFoam", "DAScalarTransportFoam"],
         }

--- a/src/adjoint/DAFvSource/DAFvSourceScalar.C
+++ b/src/adjoint/DAFvSource/DAFvSourceScalar.C
@@ -1,0 +1,369 @@
+/*---------------------------------------------------------------------------*\
+
+    DAFoam  : Discrete Adjoint with OpenFOAM
+    Version : v3
+
+\*---------------------------------------------------------------------------*/
+
+#include "DAFvSourceScalar.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+defineTypeNameAndDebug(DAFvSourceScalar, 0);
+addToRunTimeSelectionTable(DAFvSource, DAFvSourceScalar, dictionary);
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+DAFvSourceScalar::DAFvSourceScalar(
+    const word modelType,
+    const fvMesh& mesh,
+    const DAOption& daOption,
+    const DAModel& daModel,
+    const DAIndex& daIndex)
+    : DAFvSource(modelType, mesh, daOption, daModel, daIndex)
+{
+    printInterval_ = daOption.getOption<label>("printInterval");
+
+    // now we need to initialize actuatorDiskDVs_ by synchronizing the values
+    // defined in fvSource from DAOption to actuatorDiskDVs_
+    // NOTE: we need to call this function whenever we change the actuator
+    // design variables during optimization
+    this->syncDAOptionToActuatorDVs();
+
+    const dictionary& allOptions = daOption_.getAllOptions();
+
+    dictionary fvSourceSubDict = allOptions.subDict("fvSource");
+
+    forAll(fvSourceSubDict.toc(), idxI)
+    {
+        word sourceName = fvSourceSubDict.toc()[idxI];
+        dictionary sourceSubDict = fvSourceSubDict.subDict(sourceName);
+        word sourceType = sourceSubDict.getWord("source");
+
+        if (sourceType == "boxToCell")
+        {
+            scalarList min;
+            sourceSubDict.readEntry<scalarList>("min", min);
+            min_.set(sourceName, min);
+            scalarList max;
+            sourceSubDict.readEntry<scalarList>("max", max);
+            max_.set(sourceName, max);
+
+            //cylinderRadius_.set(sourceName, sourceSubDict.getScalar("radius"));
+            power_.set(sourceName, sourceSubDict.getScalar("power"));
+
+            fvSourceCellIndices_.set(sourceName, {});
+            // all available source type are in src/meshTools/sets/cellSources
+            // Example of IO parameters os in applications/utilities/mesh/manipulation/topoSet
+
+            // create a topoSet
+            autoPtr<topoSet> currentSet(
+                topoSet::New(
+                    "cellSet",
+                    mesh_,
+                    "set0",
+                    IOobject::NO_READ));
+            // we need to change the min and max because they need to
+            // be of type point; however, we can't parse point type
+            // in pyDict, we need to change them here.
+
+            point boxMin1;
+            point boxMax1;
+            boxMin1[0] = min_[sourceName][0];
+            boxMin1[1] = min_[sourceName][1];
+            boxMin1[2] = min_[sourceName][2];
+            boxMax1[0] = max_[sourceName][0];
+            boxMax1[1] = max_[sourceName][1];
+            boxMax1[2] = max_[sourceName][2];
+
+            dictionary tmpDict;
+            tmpDict.set("boxMin1", boxMin1);
+            tmpDict.set("boxMax1", boxMin1);
+            //tmpDict.set("radius", cylinderRadius_[sourceName]);
+
+            // create the source
+            autoPtr<topoSetSource> sourceSet(
+                topoSetSource::New("boxToCell", mesh_, tmpDict));
+
+            // add the sourceSet to topoSet
+            sourceSet().applyToSet(topoSetSource::NEW, currentSet());
+            // get the face index from currentSet, we need to use
+            // this special for loop
+            for (const label i : currentSet())
+            {
+                fvSourceCellIndices_[sourceName].append(i);
+            }
+
+            if (daOption_.getOption<label>("debug"))
+            {
+                Info << "fvSourceCellIndices " << fvSourceCellIndices_ << endl;
+            }
+        }
+        /*else if (sourceType == "cylinderSmooth")
+        {
+
+            // eps is a smoothing parameter, it should be the local mesh cell size in meters
+            // near the cylinder region
+            cylinderEps_.set(sourceName, sourceSubDict.getScalar("eps"));
+
+            snapCenter2Cell_.set(sourceName, sourceSubDict.lookupOrDefault<label>("snapCenter2Cell", 0));
+            if (snapCenter2Cell_[sourceName])
+            {
+                point centerPoint = {actuatorDiskDVs_[sourceName][0], actuatorDiskDVs_[sourceName][1], actuatorDiskDVs_[sourceName][2]};
+
+                // NOTE: we need to call a self-defined findCell func to make it work correctly in ADR
+                label myCellI = DAUtility::myFindCell(mesh_, centerPoint);
+
+                snappedCenterCellI_.set(sourceName, myCellI);
+                label foundCellI = 0;
+                if (snappedCenterCellI_[sourceName] >= 0)
+                {
+                    foundCellI = 1;
+                    //Pout << "snap source " << sourceName << " to center " << mesh_.C()[snappedCenterCellI_[sourceName]] << endl;
+                }
+                reduce(foundCellI, sumOp<label>());
+                if (foundCellI != 1)
+                {
+                    FatalErrorIn(" ") << "There should be only one cell found globally while "
+                                      << foundCellI << " was returned."
+                                      << " Please adjust center such that it is located completely"
+                                      << " within a cell in the mesh domain. The center should not "
+                                      << " be outside of the mesh domain or on a mesh face "
+                                      << abort(FatalError);
+                }
+
+                vector snappedCenter = vector::zero;
+                this->findGlobalSnappedCenter(snappedCenterCellI_[sourceName], snappedCenter);
+                Info << "heat source " << sourceName << " snap to center " << snappedCenter << endl;
+            }
+        }*/
+        else
+        {
+            FatalErrorIn("DAFvSourceScalar") << "source: " << sourceType << " not supported!"
+                                                 << "Options are: cylinderAnnulusToCell and cylinderSmooth!"
+                                                 << abort(FatalError);
+        }
+    }
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+void DAFvSourceScalar::calcFvSource(volScalarField& fvSource)
+{
+    /*
+    Description:
+        Assign scalar source to fvSource
+
+    Example:
+        An example of the fvSource in pyOptions in pyDAFoam can be
+        defOptions = 
+        {
+            "fvSource"
+            {
+                "source1"
+                {
+                    "type": "passiveScalar",
+                    "source": "boxToCell",
+                    "min": [0.5, 0.3, 0.1], # p1 and p2 define the axis and width
+                    "max": [0.5, 0.3, 0.5], # p2-p1 should be the axis of the cylinder
+                    "power": 101.0,  # here we should prescribe the power in W
+                },
+                "source2"
+                {
+                    "type": "passiveScalar",
+                    "source": "boxToCell",
+                    "p1": [0.5, 0.3, 0.1], # p1 and p2 define the axis and width
+                    "p2": [0.5, 0.3, 0.5], # p2-p1 should be the axis of the cylinder
+                    "power": 10.5, # here we should prescribe the scalar strength
+                }
+            }
+        }
+    */
+
+    forAll(fvSource, idxI)
+    {
+        fvSource[idxI] = 0.0;
+    }
+
+    const dictionary& allOptions = daOption_.getAllOptions();
+
+    dictionary fvSourceSubDict = allOptions.subDict("fvSource");
+
+    forAll(fvSourceSubDict.toc(), idxI)
+    {
+        word sourceName = fvSourceSubDict.toc()[idxI];
+        dictionary sourceSubDict = fvSourceSubDict.subDict(sourceName);
+        word sourceType = sourceSubDict.getWord("source");
+        // NOTE: here power should be in W. We will evenly divide the power by the
+        // total volume of the source
+        if (sourceType == "boxToCell")
+        {
+
+            scalar power = power_[sourceName];
+
+            // loop over all cell indices for this source and assign the source term
+            // ----- first loop, calculate the total volume
+            /*scalar totalV = 0.0;
+            forAll(fvSourceCellIndices_[sourceName], idxJ)
+            {
+                label cellI = fvSourceCellIndices_[sourceName][idxJ];
+                scalar cellV = mesh_.V()[cellI];
+                totalV += cellV;
+            }
+            reduce(totalV, sumOp<scalar>());
+            */
+            // ------- second loop, assign power
+            scalar sourceTotal = 0.0;
+            forAll(fvSourceCellIndices_[sourceName], idxJ)
+            {
+                // cell index
+                label cellI = fvSourceCellIndices_[sourceName][idxJ];
+
+                fvSource[cellI] = power;
+                sourceTotal += fvSource[cellI];
+            }
+
+            reduce(sourceTotal, sumOp<scalar>());
+
+            if (daOption_.getOption<word>("runStatus") == "solvePrimal")
+            {
+                if (mesh_.time().timeIndex() % printInterval_ == 0 || mesh_.time().timeIndex() == 1)
+                {
+                    Info << "Total scalar strength for " << sourceName << ": " << sourceTotal << " W." << endl;
+                }
+            }
+        }
+        /*else if (sourceType == "cylinderSmooth")
+        {
+            vector cylinderCenter =
+                {actuatorDiskDVs_[sourceName][0], actuatorDiskDVs_[sourceName][1], actuatorDiskDVs_[sourceName][2]};
+
+            if (snapCenter2Cell_[sourceName])
+            {
+                this->findGlobalSnappedCenter(snappedCenterCellI_[sourceName], cylinderCenter);
+            }
+            vector cylinderDir =
+                {actuatorDiskDVs_[sourceName][3], actuatorDiskDVs_[sourceName][4], actuatorDiskDVs_[sourceName][5]};
+            scalar radius = actuatorDiskDVs_[sourceName][6];
+            scalar cylinderLen = actuatorDiskDVs_[sourceName][7];
+            scalar power = actuatorDiskDVs_[sourceName][8];
+            vector cylinderDirNorm = cylinderDir / mag(cylinderDir);
+            scalar eps = cylinderEps_[sourceName];
+
+            // first loop, calculate the total volume
+            scalar volumeTotal = 0.0;
+            forAll(mesh_.cells(), cellI)
+            {
+                // the cell center coordinates of this cellI
+                vector cellC = mesh_.C()[cellI];
+                // cell center to disk center vector
+                vector cellC2AVec = cellC - cylinderCenter;
+                // tmp tensor for calculating the axial/radial components of cellC2AVec
+                tensor cellC2AVecE(tensor::zero);
+                cellC2AVecE.xx() = cellC2AVec.x();
+                cellC2AVecE.yy() = cellC2AVec.y();
+                cellC2AVecE.zz() = cellC2AVec.z();
+
+                // now we need to decompose cellC2AVec into axial and radial components
+                // the axial component of cellC2AVec vector
+                vector cellC2AVecA = cellC2AVecE & cylinderDirNorm;
+                // the radial component of cellC2AVec vector
+                vector cellC2AVecR = cellC2AVec - cellC2AVecA;
+
+                // the magnitude of radial component of cellC2AVecR
+                scalar cellC2AVecRLen = mag(cellC2AVecR);
+                // the magnitude of axial component of cellC2AVecR
+                scalar cellC2AVecALen = mag(cellC2AVecA);
+
+                scalar axialSmoothC = 1.0;
+                scalar radialSmoothC = 1.0;
+
+                scalar halfL = cylinderLen / 2.0;
+
+                if (cellC2AVecALen > halfL)
+                {
+                    scalar d2 = (cellC2AVecALen - halfL) * (cellC2AVecALen - halfL);
+                    axialSmoothC = exp(-d2 / eps / eps);
+                }
+
+                if (cellC2AVecRLen > radius)
+                {
+                    scalar d2 = (cellC2AVecRLen - radius) * (cellC2AVecRLen - radius);
+                    radialSmoothC = exp(-d2 / eps / eps);
+                }
+                volumeTotal += axialSmoothC * radialSmoothC * mesh_.V()[cellI];
+            }
+            reduce(volumeTotal, sumOp<scalar>());
+
+            // second loop, calculate fvSource
+            scalar sourceTotal = 0.0;
+            forAll(mesh_.cells(), cellI)
+            {
+                // the cell center coordinates of this cellI
+                vector cellC = mesh_.C()[cellI];
+                // cell center to disk center vector
+                vector cellC2AVec = cellC - cylinderCenter;
+                // tmp tensor for calculating the axial/radial components of cellC2AVec
+                tensor cellC2AVecE(tensor::zero);
+                cellC2AVecE.xx() = cellC2AVec.x();
+                cellC2AVecE.yy() = cellC2AVec.y();
+                cellC2AVecE.zz() = cellC2AVec.z();
+
+                // now we need to decompose cellC2AVec into axial and radial components
+                // the axial component of cellC2AVec vector
+                vector cellC2AVecA = cellC2AVecE & cylinderDirNorm;
+                // the radial component of cellC2AVec vector
+                vector cellC2AVecR = cellC2AVec - cellC2AVecA;
+
+                // the magnitude of radial component of cellC2AVecR
+                scalar cellC2AVecRLen = mag(cellC2AVecR);
+                // the magnitude of axial component of cellC2AVecR
+                scalar cellC2AVecALen = mag(cellC2AVecA);
+
+                scalar axialSmoothC = 1.0;
+                scalar radialSmoothC = 1.0;
+
+                scalar halfL = cylinderLen / 2.0;
+
+                if (cellC2AVecALen > halfL)
+                {
+                    scalar d2 = (cellC2AVecALen - halfL) * (cellC2AVecALen - halfL);
+                    axialSmoothC = exp(-d2 / eps / eps);
+                }
+
+                if (cellC2AVecRLen > radius)
+                {
+                    scalar d2 = (cellC2AVecRLen - radius) * (cellC2AVecRLen - radius);
+                    radialSmoothC = exp(-d2 / eps / eps);
+                }
+
+                fvSource[cellI] += power / volumeTotal * axialSmoothC * radialSmoothC;
+                sourceTotal += power / volumeTotal * axialSmoothC * radialSmoothC * mesh_.V()[cellI];
+            }
+
+            reduce(sourceTotal, sumOp<scalar>());
+
+            if (daOption_.getOption<word>("runStatus") == "solvePrimal")
+            {
+                if (mesh_.time().timeIndex() % printInterval_ == 0 || mesh_.time().timeIndex() == 1)
+                {
+                    Info << "Total volume for " << sourceName << ": " << volumeTotal << " m^3" << endl;
+                    Info << "Total heat source for " << sourceName << ": " << sourceTotal << " W." << endl;
+                }
+            }
+        }*/
+        else
+        {
+            FatalErrorIn("DAFvSourceScalar") << "source: " << sourceType << " not supported!"
+                                                 << "Options are: cylinderAnnulusToCell and cylinderSmooth!"
+                                                 << abort(FatalError);
+        }
+    }
+
+    fvSource.correctBoundaryConditions();
+}
+
+} // End namespace Foam
+
+// ************************************************************************* //

--- a/src/adjoint/DAFvSource/DAFvSourceScalar.H
+++ b/src/adjoint/DAFvSource/DAFvSourceScalar.H
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------*\
+
+    DAFoam  : Discrete Adjoint with OpenFOAM
+    Version : v3
+
+    Description:
+        Child class for passive scalar 
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef DAFvSourceScalar_H
+#define DAFvSourceScalar_H
+
+#include "DAFvSource.H"
+#include "addToRunTimeSelectionTable.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+      Class DAFvSourceScalar Declaration
+\*---------------------------------------------------------------------------*/
+
+class DAFvSourceScalar
+    : public DAFvSource
+{
+
+protected:
+    /// HashTable that contains lists of cell indices that are within the scalar source space
+    HashTable<labelList> fvSourceCellIndices_;
+
+    HashTable<scalarList> min_;
+    HashTable<scalarList> max_;
+    //HashTable<scalar> cylinderRadius_;
+    HashTable<scalar> power_;
+    HashTable<scalar> cylinderEps_;
+
+    /// print interval for primal and adjoint
+    label printInterval_;
+
+    /// whether to snap the center to a cell in the mesh if yes the center will move with the mesh
+    HashTable<label> snapCenter2Cell_;
+
+    /// the cell index for the center if snapCenter2Cell_ = 1
+    HashTable<label> snappedCenterCellI_;
+
+public:
+    TypeName("passiveScalar");
+    // Constructors
+
+    //- Construct from components
+    DAFvSourceScalar(
+        const word modelType,
+        const fvMesh& mesh,
+        const DAOption& daOption,
+        const DAModel& daModel,
+        const DAIndex& daIndex);
+
+    //- Destructor
+    virtual ~DAFvSourceScalar()
+    {
+    }
+
+    /// compute the FvSource term
+    virtual void calcFvSource(volScalarField& fvSource);
+};
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/adjoint/DAResidual/DAResidualMySimpleTFoam.C
+++ b/src/adjoint/DAResidual/DAResidualMySimpleTFoam.C
@@ -1,0 +1,255 @@
+/*---------------------------------------------------------------------------*\
+
+    DAFoam  : Discrete Adjoint with OpenFOAM
+    Version : v3
+
+\*---------------------------------------------------------------------------*/
+
+#include "DAResidualMySimpleTFoam.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+defineTypeNameAndDebug(DAResidualMySimpleTFoam, 0);
+addToRunTimeSelectionTable(DAResidual, DAResidualMySimpleTFoam, dictionary);
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+DAResidualMySimpleTFoam::DAResidualMySimpleTFoam(
+    const word modelType,
+    const fvMesh& mesh,
+    const DAOption& daOption,
+    const DAModel& daModel,
+    const DAIndex& daIndex)
+    : DAResidual(modelType, mesh, daOption, daModel, daIndex),
+      // initialize and register state variables and their residuals, we use macros defined in macroFunctions.H
+      setResidualClassMemberVector(U, dimensionSet(0, 1, -2, 0, 0, 0, 0)),
+      setResidualClassMemberScalar(p, dimensionSet(0, 0, -1, 0, 0, 0, 0)),
+      setResidualClassMemberScalar(T, dimensionSet(0, 0, -1, 1, 0, 0, 0)),
+      setResidualClassMemberPhi(phi),
+      alphaPorosity_(const_cast<volScalarField&>(
+          mesh_.thisDb().lookupObject<volScalarField>("alphaPorosity"))),
+      fTSource_(const_cast<volScalarField&>(
+          mesh_.thisDb().lookupObject<volScalarField>("fTSource"))),
+      fvSource_(const_cast<volVectorField&>(
+          mesh_.thisDb().lookupObject<volVectorField>("fvSource"))),
+      fvOptions_(fv::options::New(mesh)),
+      alphat_(const_cast<volScalarField&>(
+          mesh_.thisDb().lookupObject<volScalarField>("alphat"))),
+      daTurb_(const_cast<DATurbulenceModel&>(daModel.getDATurbulenceModel())),
+      // create simpleControl
+      simple_(const_cast<fvMesh&>(mesh)),
+      MRF_(const_cast<IOMRFZoneListDF&>(
+          mesh_.thisDb().lookupObject<IOMRFZoneListDF>("MRFProperties")))
+{
+    // initialize fvSource
+    const dictionary& allOptions = daOption.getAllOptions();
+    if (allOptions.subDict("fvSource").toc().size() != 0)
+    {
+        hasFvSource_ = 1;
+    }
+
+    // initialize the Prandtl number from transportProperties
+    IOdictionary transportProperties(
+        IOobject(
+            "transportProperties",
+            mesh.time().constant(),
+            mesh,
+            IOobject::MUST_READ,
+            IOobject::NO_WRITE,
+            false));
+    Pr_ = readScalar(transportProperties.lookup("Pr"));
+    Prt_ = readScalar(transportProperties.lookup("Prt"));
+
+    // this is just a dummy call because we need to run the constrain once 
+    // to initialize fvOptions, before we can use it. Otherwise, we may get
+    // a seg fault when we call fvOptions_.correct(U_) in updateIntermediateVars
+    fvVectorMatrix UEqn(
+        fvm::div(phi_, U_)
+        - fvOptions_(U_));
+    fvOptions_.constrain(UEqn);
+    /*fvScalarMatrix TEqn(
+        fvm::div(phi_, T_)
+        - fvOptions_(T_));
+    fvOptions_.constrain(TEqn);*/
+
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+void DAResidualMySimpleTFoam::clear()
+{
+    /*
+    Description:
+        Clear all members to avoid memory leak because we will initalize
+        multiple objects of DAResidual. Here we need to delete all members
+        in the parent and child classes
+    */
+    URes_.clear();
+    pRes_.clear();
+    TRes_.clear();
+    phiRes_.clear();
+}
+
+void DAResidualMySimpleTFoam::calcResiduals(const dictionary& options)
+{
+    /*
+    Description:
+        This is the function to compute residuals.
+    
+    Input:
+        options.isPC: 1 means computing residuals for preconditioner matrix.
+        This essentially use the first order scheme for div(phi,U)
+
+        p_, U_, phi_, etc: State variables in OpenFOAM
+    
+    Output:
+        URes_, pRes_, phiRes_: residual field variables
+    */
+
+    // We dont support MRF and fvOptions so all the related lines are commented
+    // out for now
+
+    // ******** U Residuals **********
+    // copied and modified from UEqn.H
+
+    word divUScheme = "div(phi,U)";
+
+    label isPC = options.getLabel("isPC");
+
+    if (isPC)
+    {
+        divUScheme = "div(pc)";
+    }
+
+    if (hasFvSource_)
+    {
+        DAFvSource& daFvSource(const_cast<DAFvSource&>(
+            mesh_.thisDb().lookupObject<DAFvSource>("DAFvSource")));
+        daFvSource.calcFvSource(fvSource_);
+    }
+
+    tmp<fvVectorMatrix> tUEqn(
+        fvm::div(phi_, U_, divUScheme)
+        + fvm::Sp(alphaPorosity_, U_)
+        + MRF_.DDt(U_)
+        + daTurb_.divDevReff(U_)
+        - fvSource_
+        - fvOptions_(U_));
+    fvVectorMatrix& UEqn = tUEqn.ref();
+
+    UEqn.relax();
+
+    fvOptions_.constrain(UEqn);
+
+    URes_ = (UEqn & U_) + fvc::grad(p_);
+    normalizeResiduals(URes);
+
+    // ******** p Residuals **********
+    // copied and modified from pEqn.H
+    // NOTE manually set pRefCell and pRefValue
+    label pRefCell = 0;
+    scalar pRefValue = 0.0;
+
+    volScalarField rAU(1.0 / UEqn.A());
+    //***************** NOTE *******************
+    // constrainHbyA has been used since OpenFOAM-v1606; however, it may degrade the accuracy of derivatives
+    // because constraining variables will create discontinuity. Here we have a option to use the old
+    // implementation in OpenFOAM-3.0+ and before (no constraint for HbyA)
+    autoPtr<volVectorField> HbyAPtr = nullptr;
+    label useConstrainHbyA = daOption_.getOption<label>("useConstrainHbyA");
+    if (useConstrainHbyA)
+    {
+        HbyAPtr.reset(new volVectorField(constrainHbyA(rAU * UEqn.H(), U_, p_)));
+    }
+    else
+    {
+        HbyAPtr.reset(new volVectorField("HbyA", U_));
+        HbyAPtr() = rAU * UEqn.H();
+    }
+    volVectorField& HbyA = HbyAPtr();
+
+    surfaceScalarField phiHbyA("phiHbyA", fvc::flux(HbyA));
+
+    MRF_.makeRelative(phiHbyA);
+
+    adjustPhi(phiHbyA, U_, p_);
+
+    tmp<volScalarField> rAtU(rAU);
+
+    if (simple_.consistent())
+    {
+        rAtU = 1.0 / (1.0 / rAU - UEqn.H1());
+        phiHbyA += fvc::interpolate(rAtU() - rAU) * fvc::snGrad(p_) * mesh_.magSf();
+        HbyA -= (rAU - rAtU()) * fvc::grad(p_);
+    }
+
+    tUEqn.clear();
+
+    // Update the pressure BCs to ensure flux consistency
+    constrainPressure(p_, U_, phiHbyA, rAtU(), MRF_);
+
+    fvScalarMatrix pEqn(
+        fvm::laplacian(rAtU(), p_)
+        == fvc::div(phiHbyA));
+    pEqn.setReference(pRefCell, pRefValue);
+
+    pRes_ = pEqn & p_;
+    normalizeResiduals(pRes);
+
+    // ******** phi Residuals **********
+    // copied and modified from pEqn.H
+    phiRes_ = phiHbyA - pEqn.flux() - phi_;
+    // need to normalize phiRes
+    normalizePhiResiduals(phiRes);
+
+    // ******** T Residuals **************
+    volScalarField alphaEff("alphaEff", daTurb_.nu() / Pr_ + alphat_);
+
+    fvScalarMatrix TEqn(
+        fvm::div(phi_, T_)
+        - fvm::laplacian(alphaEff, T_)
+        - fTSource_
+        );
+
+    TEqn.relax();
+    //fvOptions_.constrain(TEqn);
+
+    TRes_ = TEqn & T_;
+    normalizeResiduals(TRes);
+}
+
+void DAResidualMySimpleTFoam::updateIntermediateVariables()
+{
+    /* 
+    Description:
+        Update the intermediate variables that depend on the state variables
+    */
+
+    alphat_ = daTurb_.getNut() / Prt_;
+    alphat_.correctBoundaryConditions();
+
+    MRF_.correctBoundaryVelocity(U_);
+
+    fvOptions_.correct(U_);
+    fvOptions_.correct(T_);
+
+}
+
+void DAResidualMySimpleTFoam::correctBoundaryConditions()
+{
+    /* 
+    Description:
+        Update the boundary condition for all the states in the selected solver
+    */
+
+    U_.correctBoundaryConditions();
+    T_.correctBoundaryConditions();
+    p_.correctBoundaryConditions();
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// ************************************************************************* //

--- a/src/adjoint/DAResidual/DAResidualMySimpleTFoam.H
+++ b/src/adjoint/DAResidual/DAResidualMySimpleTFoam.H
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------------------------*\
+
+    DAFoam  : Discrete Adjoint with OpenFOAM
+    Version : v3
+
+    Description:
+        Child class for DAMySimpleTFoam
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef DAResidualMySimpleTFoam_H
+#define DAResidualMySimpleTFoam_H
+
+#include "DAResidual.H"
+#include "addToRunTimeSelectionTable.H"
+#include "simpleControl.H"
+#include "adjustPhi.H"
+#include "constrainPressure.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+      Class DAResidualMySimpleTFoam Declaration
+\*---------------------------------------------------------------------------*/
+
+class DAResidualMySimpleTFoam
+    : public DAResidual
+{
+protected:
+    /// \name These are state variables, state residuals, and partial derivatives
+    //@{
+    volVectorField& U_;
+    volVectorField URes_;
+
+    volScalarField& p_;
+    volScalarField pRes_;
+
+    volScalarField& T_;
+    volScalarField TRes_;
+
+    surfaceScalarField& phi_;
+    surfaceScalarField phiRes_;
+    //@}
+
+    /// alpha porosity term
+    volScalarField& alphaPorosity_;
+
+    /// fvSource term
+    volVectorField& fvSource_;
+    
+    /// fTSource term
+    volScalarField& fTSource_;
+
+    /// fvOptions term
+    fv::options& fvOptions_;
+
+    volScalarField& alphat_;
+
+    scalar Pr_ = -9999.0;
+
+    scalar Prt_ = -9999.0;
+
+    /// DATurbulenceModel object
+    DATurbulenceModel& daTurb_;
+
+    /// simpleControl object which will be initialized in this class
+    simpleControl simple_;
+
+    /// Multiple Reference Frame
+    IOMRFZoneListDF& MRF_;
+
+    /// whether to have fvSource term
+    label hasFvSource_ = 0;
+
+public:
+    TypeName("DAMySimpleTFoam");
+    // Constructors
+
+    //- Construct from components
+    DAResidualMySimpleTFoam(
+        const word modelType,
+        const fvMesh& mesh,
+        const DAOption& daOption,
+        const DAModel& daModel,
+        const DAIndex& daIndex);
+
+    //- Destructor
+    virtual ~DAResidualMySimpleTFoam()
+    {
+    }
+
+    // Members
+
+    /// clear the members
+    virtual void clear();
+
+    /// compute residual
+    virtual void calcResiduals(const dictionary& options);
+
+    /// update any intermediate variables that are dependent on state variables and are used in calcResiduals
+    virtual void updateIntermediateVariables();
+
+    /// update the boundary condition for all the states in the selected solver
+    virtual void correctBoundaryConditions();
+};
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/adjoint/DASolver/DAMySimpleTFoam/DAMySimpleTFoam.C
+++ b/src/adjoint/DASolver/DAMySimpleTFoam/DAMySimpleTFoam.C
@@ -1,0 +1,216 @@
+/*---------------------------------------------------------------------------*\
+
+    DAFoam  : Discrete Adjoint with OpenFOAM
+    Version : v3
+
+    This class is modified from OpenFOAM's source code
+    applications/solvers/incompressible/simpleFoam
+
+    OpenFOAM: The Open Source CFD Toolbox
+
+    Copyright (C): 2011-2016 OpenFOAM Foundation
+
+    OpenFOAM License:
+
+        OpenFOAM is free software: you can redistribute it and/or modify it
+        under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+    
+        OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+        ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+        FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+        for more details.
+    
+        You should have received a copy of the GNU General Public License
+        along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "DAMySimpleTFoam.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+defineTypeNameAndDebug(DAMySimpleTFoam, 0);
+addToRunTimeSelectionTable(DASolver, DAMySimpleTFoam, dictionary);
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+DAMySimpleTFoam::DAMySimpleTFoam(
+    char* argsAll,
+    PyObject* pyOptions)
+    : DASolver(argsAll, pyOptions),
+      simplePtr_(nullptr),
+      pPtr_(nullptr),
+      UPtr_(nullptr),
+      phiPtr_(nullptr),
+      alphaPorosityPtr_(nullptr),
+      laminarTransportPtr_(nullptr),
+      turbulencePtr_(nullptr),
+      daTurbulenceModelPtr_(nullptr),
+      daFvSourcePtr_(nullptr),
+      fvSourcePtr_(nullptr),
+      MRFPtr_(nullptr),
+      PrPtr_(nullptr),
+      PrtPtr_(nullptr),
+      TPtr_(nullptr),
+      alphatPtr_(nullptr)
+{
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+void DAMySimpleTFoam::initSolver()
+{
+    /*
+    Description:
+        Initialize variables for DASolver
+    */
+
+    Info << "Initializing fields for DAMySimpleTFoam" << endl;
+    Time& runTime = runTimePtr_();
+    fvMesh& mesh = meshPtr_();
+#include "createSimpleControlPython.H"
+#include "createFieldsSimpleT.H"
+#include "createAdjointIncompressible.H"
+    // initialize checkMesh
+    daCheckMeshPtr_.reset(new DACheckMesh(daOptionPtr_(), runTime, mesh));
+
+    daLinearEqnPtr_.reset(new DALinearEqn(mesh, daOptionPtr_()));
+
+    this->setDAObjFuncList();
+
+    // initialize fvSource and compute the source term
+    const dictionary& allOptions = daOptionPtr_->getAllOptions();
+    if (allOptions.subDict("fvSource").toc().size() != 0)
+    {
+        hasFvSource_ = 1;
+        Info << "Initializing DASource" << endl;
+        word sourceName = allOptions.subDict("fvSource").toc()[0];
+        word fvSourceType = allOptions.subDict("fvSource").subDict(sourceName).getWord("type");
+        daFvSourcePtr_.reset(DAFvSource::New(
+            fvSourceType, mesh, daOptionPtr_(), daModelPtr_(), daIndexPtr_()));
+    }
+}
+
+label DAMySimpleTFoam::solvePrimal(
+    const Vec xvVec,
+    Vec wVec)
+{
+    /*
+    Description:
+        Call the primal solver to get converged state variables
+
+    Input:
+        xvVec: a vector that contains all volume mesh coordinates
+
+    Output:
+        wVec: state variable vector
+    */
+
+#include "createRefsSimpleT.H"
+#include "createFvOptions.H"
+
+    // change the run status
+    daOptionPtr_->setOption<word>("runStatus", "solvePrimal");
+
+    // call correctNut, this is equivalent to turbulence->validate();
+    daTurbulenceModelPtr_->updateIntermediateVariables();
+
+    Info << "\nStarting time loop\n"
+         << endl;
+
+    // deform the mesh based on the xvVec
+    this->pointVec2OFMesh(xvVec);
+
+    // check mesh quality
+    label meshOK = this->checkMesh();
+
+    if (!meshOK)
+    {
+        this->writeFailedMesh();
+        return 1;
+    }
+
+    // if the forwardModeAD is active, we need to set the seed here
+#include "setForwardADSeeds.H"
+
+    // check if the parameters are set in the Python layer
+    daRegressionPtr_->validate();
+
+    primalMinRes_ = 1e10;
+    label printInterval = daOptionPtr_->getOption<label>("printInterval");
+    label printToScreen = 0;
+    label regModelFail = 0;
+    while (this->loop(runTime)) // using simple.loop() will have seg fault in parallel
+    {
+
+        printToScreen = this->isPrintTime(runTime, printInterval);
+
+        if (printToScreen)
+        {
+            Info << "Time = " << runTime.timeName() << nl << endl;
+        }
+
+        p.storePrevIter();
+
+        // --- Pressure-velocity SIMPLE corrector
+        {
+#include "UEqnSimpleT.H"
+#include "pEqnSimpleT.H"
+#include "TEqnSimpleT.H"
+        }
+
+        // update the output field value at each iteration, if the regression model is active
+        regModelFail = daRegressionPtr_->compute();
+
+        laminarTransport.correct();
+        daTurbulenceModelPtr_->correct(printToScreen);
+
+        if (this->validateStates())
+        {
+            // write data to files and quit
+            runTime.writeNow();
+            mesh.write();
+            return 1;
+        }
+
+        if (printToScreen)
+        {
+            daTurbulenceModelPtr_->printYPlus();
+
+            this->printAllObjFuncs();
+
+            daRegressionPtr_->printInputInfo();
+
+            Info << "ExecutionTime = " << runTime.elapsedCpuTime() << " s"
+                 << "  ClockTime = " << runTime.elapsedClockTime() << " s"
+                 << nl << endl;
+        }
+
+        runTime.write();
+    }
+
+    if (regModelFail != 0)
+    {
+        return 1;
+    }
+
+    this->calcPrimalResidualStatistics("print");
+
+    // primal converged, assign the OpenFoam fields to the state vec wVec
+    this->ofField2StateVec(wVec);
+
+    // write the mesh to files
+    mesh.write();
+
+    Info << "End\n"
+         << endl;
+
+    return this->checkResidualTol();
+}
+
+} // End namespace Foam
+
+// ************************************************************************* //

--- a/src/adjoint/DASolver/DAMySimpleTFoam/DAMySimpleTFoam.H
+++ b/src/adjoint/DASolver/DAMySimpleTFoam/DAMySimpleTFoam.H
@@ -1,0 +1,152 @@
+/*---------------------------------------------------------------------------*\
+
+    DAFoam  : Discrete Adjoint with OpenFOAM
+    Version : v3
+
+    Description:
+        Child class for DASimpleTFoam
+    
+    This class is modified from OpenFOAM's source code
+    applications/solvers/incompressible/simpleFoam
+
+    OpenFOAM: The Open Source CFD Toolbox
+
+    Copyright (C): 2011-2016 OpenFOAM Foundation
+
+    OpenFOAM License:
+
+        OpenFOAM is free software: you can redistribute it and/or modify it
+        under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+    
+        OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+        ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+        FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+        for more details.
+    
+        You should have received a copy of the GNU General Public License
+        along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef DAMySimpleTFoam_H
+#define DAMySimpleTFoam_H
+
+#include "DASolver.H"
+#include "addToRunTimeSelectionTable.H"
+#include "singlePhaseTransportModel.H"
+#include "turbulentTransportModel.H"
+#include "simpleControl.H"
+#include "DARegDbSinglePhaseTransportModel.H"
+#include "DARegDbTurbulenceModelIncompressible.H"
+#include "DAFvSource.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+      Class DAMySimpleTFoam Declaration
+\*---------------------------------------------------------------------------*/
+
+class DAMySimpleTFoam
+    : public DASolver
+{
+
+protected:
+
+    /// simple pointer
+    autoPtr<simpleControl> simplePtr_;
+
+    /// pressure field pointer
+    autoPtr<volScalarField> pPtr_;
+
+    /// velocity field pointer
+    autoPtr<volVectorField> UPtr_;
+
+    /// surface flux field pointer
+    autoPtr<surfaceScalarField> phiPtr_;
+
+    /// alpha porosity
+    autoPtr<volScalarField> alphaPorosityPtr_;
+
+    /// laminar transport properties pointer
+    autoPtr<singlePhaseTransportModel> laminarTransportPtr_;
+
+    /// turbulence pointer
+    autoPtr<incompressible::turbulenceModel> turbulencePtr_;
+
+    /// DATurbulenceModel pointer
+    autoPtr<DATurbulenceModel> daTurbulenceModelPtr_;
+
+    /// DASource pointer
+    autoPtr<DAFvSource> daFvSourcePtr_;
+
+    /// fvSource term 
+    autoPtr<volVectorField> fvSourcePtr_;
+    
+    /// fTSource term 
+    autoPtr<volScalarField> fTSourcePtr_;
+
+    /// MRF pointer
+    autoPtr<IOMRFZoneListDF> MRFPtr_;
+
+    /// whether to have fvSource term
+    label hasFvSource_ = 0;
+
+    /// continuity error
+    scalar cumulativeContErr_ = 0.0;
+
+    /// pressure referefence cell id
+    label pRefCell_ = 0;
+
+    /// pressure reference value
+    scalar pRefValue_ = 0.0;
+
+    /// Prandtl number pointer
+    autoPtr<dimensionedScalar> PrPtr_;
+
+    /// Turbulence Prandtl pointer
+    autoPtr<dimensionedScalar> PrtPtr_;
+
+    /// temperature field pointer
+    autoPtr<volScalarField> TPtr_;
+
+    /// thermal diffusivity field pointer
+    autoPtr<volScalarField> alphatPtr_;
+    
+public:
+    TypeName("DAMySimpleTFoam");
+    // Constructors
+
+    //- Construct from components
+    DAMySimpleTFoam(
+        char* argsAll,
+        PyObject* pyOptions);
+
+    //- Destructor
+    virtual ~DAMySimpleTFoam()
+    {
+    }
+
+    /// initialize fields and variables
+    virtual void initSolver();
+
+    /// solve the primal equations
+    virtual label solvePrimal(
+        const Vec xvVec,
+        Vec wVec);
+
+};
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/adjoint/DASolver/DAMySimpleTFoam/TEqnSimpleT.H
+++ b/src/adjoint/DASolver/DAMySimpleTFoam/TEqnSimpleT.H
@@ -1,0 +1,29 @@
+{
+    if (hasFvSource_)
+	{
+    	daFvSourcePtr_->calcFvSource(fTSource);
+	}
+    alphat = turbulencePtr_->nut() / Prt;
+    alphat.correctBoundaryConditions();
+
+    volScalarField alphaEff("alphaEff", turbulencePtr_->nu() / Pr + alphat);
+
+    fvScalarMatrix TEqn(
+        fvm::div(phi, T)
+        - fvm::laplacian(alphaEff, T)
+        - fTSource
+          );
+
+    TEqn.relax();
+
+    // get the solver performance info such as initial
+    // and final residuals
+    SolverPerformance<scalar> solverT = TEqn.solve();
+
+    this->primalResidualControl<scalar>(solverT, printToScreen, printInterval, "T");
+    
+    fvOptions.correct(T);
+
+    // bound T
+    DAUtility::boundVar(allOptions, T, printToScreen);
+}

--- a/src/adjoint/DASolver/DAMySimpleTFoam/UEqnSimpleT.H
+++ b/src/adjoint/DASolver/DAMySimpleTFoam/UEqnSimpleT.H
@@ -1,0 +1,33 @@
+// Momentum predictor
+
+MRF.correctBoundaryVelocity(U);
+
+if (hasFvSource_)
+{
+    daFvSourcePtr_->calcFvSource(fvSource);
+}
+
+tmp<fvVectorMatrix> tUEqn(
+    fvm::div(phi, U)
+    + fvm::Sp(alphaPorosity, U)
+    + MRF.DDt(U)
+    + turbulencePtr_->divDevReff(U)
+    - fvSource
+    - fvOptions(U));
+fvVectorMatrix& UEqn = tUEqn.ref();
+
+UEqn.relax();
+
+if (simple.momentumPredictor())
+{
+    // get the solver performance info such as initial
+    // and final residuals
+    SolverPerformance<vector> solverU = solve(UEqn == -fvc::grad(p));
+
+    this->primalResidualControl<vector>(solverU, printToScreen, printInterval, "U");
+
+    fvOptions.correct(U);
+}
+
+// bound U
+DAUtility::boundVar(allOptions, U, printToScreen);

--- a/src/adjoint/DASolver/DAMySimpleTFoam/createFieldsSimpleT.H
+++ b/src/adjoint/DASolver/DAMySimpleTFoam/createFieldsSimpleT.H
@@ -1,0 +1,126 @@
+Info << "Reading field p\n"
+     << endl;
+pPtr_.reset(
+    new volScalarField(
+        IOobject(
+            "p",
+            runTime.timeName(),
+            mesh,
+            IOobject::MUST_READ,
+            IOobject::AUTO_WRITE),
+        mesh));
+volScalarField& p = pPtr_();
+
+Info << "Reading field T\n"
+     << endl;
+TPtr_.reset(
+    new volScalarField(
+        IOobject(
+            "T",
+            runTime.timeName(),
+            mesh,
+            IOobject::MUST_READ,
+            IOobject::AUTO_WRITE),
+        mesh));
+
+Info << "Reading field U\n"
+     << endl;
+UPtr_.reset(
+    new volVectorField(
+        IOobject(
+            "U",
+            runTime.timeName(),
+            mesh,
+            IOobject::MUST_READ,
+            IOobject::AUTO_WRITE),
+        mesh));
+volVectorField& U = UPtr_();
+
+#include "createPhiPython.H"
+
+// create alpha porosity term
+alphaPorosityPtr_.reset(
+    new volScalarField(
+        IOobject(
+            "alphaPorosity",
+            runTime.timeName(),
+            mesh,
+            IOobject::READ_IF_PRESENT,
+            IOobject::AUTO_WRITE),
+        mesh,
+        dimensionedScalar("alphaPorosity", dimensionSet(0, 0, -1, 0, 0, 0, 0), pTraits<scalar>::zero),
+        zeroGradientFvPatchField<scalar>::typeName));
+
+// actuator related stuff
+Info << "Creating source term. " << endl;
+/*fvSourcePtr_.reset(
+    new volVectorField(
+        IOobject(
+            "fvSource",
+            runTime.timeName(),
+            mesh,
+            IOobject::NO_READ,
+            IOobject::AUTO_WRITE),
+        mesh,
+        dimensionedVector("fvSource", dimensionSet(0, 1, -2, 0, 0, 0, 0), vector::zero),
+        zeroGradientFvPatchField<vector>::typeName));
+*/
+fvSourcePtr_.reset(
+    new volVectorField(
+        IOobject(
+            "fvSource",
+            runTime.timeName(),
+            mesh,
+            IOobject::MUST_READ,
+            IOobject::AUTO_WRITE),
+        mesh));
+
+volVectorField& fvSource = fvSourcePtr_();
+
+Info << "Creating scalar source term. " << endl;
+
+fTSourcePtr_.reset(
+    new volScalarField(
+        IOobject(
+            "fTSource",
+            runTime.timeName(),
+            mesh,
+            IOobject::MUST_READ,
+            IOobject::AUTO_WRITE),
+        mesh));
+
+volScalarField& fTSource = fTSourcePtr_();
+
+setRefCell(p, simple.dict(), pRefCell_, pRefValue_);
+mesh.setFluxRequired(p.name());
+
+laminarTransportPtr_.reset(
+    new singlePhaseTransportModel(U, phi));
+singlePhaseTransportModel& laminarTransport = laminarTransportPtr_();
+
+// Laminar Prandtl number
+PrPtr_.reset(
+    new dimensionedScalar("Pr", dimless, laminarTransport));
+
+// Turbulent Prandtl number
+PrtPtr_.reset(
+    new dimensionedScalar("Prt", dimless, laminarTransport));
+
+// kinematic turbulent thermal thermal conductivity m2/s
+Info << "Reading field alphat\n"
+     << endl;
+alphatPtr_.reset(
+    new volScalarField(
+        IOobject(
+            "alphat",
+            runTime.timeName(),
+            mesh,
+            IOobject::MUST_READ,
+            IOobject::AUTO_WRITE),
+        mesh));
+
+turbulencePtr_.reset(
+    incompressible::turbulenceModel::New(U, phi, laminarTransport));
+
+// create MRF
+MRFPtr_.reset(new IOMRFZoneListDF(mesh));

--- a/src/adjoint/DASolver/DAMySimpleTFoam/createRefsSimpleT.H
+++ b/src/adjoint/DASolver/DAMySimpleTFoam/createRefsSimpleT.H
@@ -1,0 +1,21 @@
+Time& runTime = runTimePtr_();
+// reset time to 0
+runTime.setTime(0.0, 0);
+fvMesh& mesh = meshPtr_();
+simpleControl& simple = simplePtr_();
+volScalarField& p = pPtr_();
+volVectorField& U = UPtr_();
+surfaceScalarField& phi = phiPtr_();
+volScalarField& alphaPorosity = alphaPorosityPtr_();
+singlePhaseTransportModel& laminarTransport = laminarTransportPtr_();
+scalar& cumulativeContErr = cumulativeContErr_;
+label& pRefCell = pRefCell_;
+scalar& pRefValue = pRefValue_;
+volVectorField& fvSource = fvSourcePtr_();
+volScalarField& fTSource = fTSourcePtr_();
+IOMRFZoneListDF& MRF = MRFPtr_();
+volScalarField& T = TPtr_();
+dimensionedScalar Pr = PrPtr_();
+dimensionedScalar Prt = PrtPtr_();
+volScalarField& alphat = alphatPtr_();
+const dictionary& allOptions = daOptionPtr_->getAllOptions();

--- a/src/adjoint/DASolver/DAMySimpleTFoam/pEqnSimpleT.H
+++ b/src/adjoint/DASolver/DAMySimpleTFoam/pEqnSimpleT.H
@@ -1,0 +1,77 @@
+{
+    volScalarField rAU(1.0 / UEqn.A());
+    //***************** NOTE *******************
+    // constrainHbyA has been used since OpenFOAM-v1606; however, it may degrade the accuracy of derivatives
+    // because constraining variables will create discontinuity. Here we have a option to use the old
+    // implementation in OpenFOAM-3.0+ and before (no constraint for HbyA)
+    autoPtr<volVectorField> HbyAPtr = nullptr;
+    label useConstrainHbyA = daOptionPtr_->getOption<label>("useConstrainHbyA");
+    if (useConstrainHbyA)
+    {
+        HbyAPtr.reset(new volVectorField(constrainHbyA(rAU * UEqn.H(), U, p)));
+    }
+    else
+    {
+        HbyAPtr.reset(new volVectorField("HbyA", U));
+        HbyAPtr() = rAU * UEqn.H();
+    }
+    volVectorField& HbyA = HbyAPtr();
+    surfaceScalarField phiHbyA("phiHbyA", fvc::flux(HbyA));
+
+    MRF.makeRelative(phiHbyA);
+
+    adjustPhi(phiHbyA, U, p);
+
+    tmp<volScalarField> rAtU(rAU);
+
+    if (simple.consistent())
+    {
+        rAtU = 1.0 / (1.0 / rAU - UEqn.H1());
+        phiHbyA +=
+            fvc::interpolate(rAtU() - rAU) * fvc::snGrad(p) * mesh.magSf();
+        HbyA -= (rAU - rAtU()) * fvc::grad(p);
+    }
+
+    tUEqn.clear();
+
+    // Update the pressure BCs to ensure flux consistency
+    constrainPressure(p, U, phiHbyA, rAtU(), MRF);
+
+    // Non-orthogonal pressure corrector loop
+    while (simple.correctNonOrthogonal())
+    {
+        fvScalarMatrix pEqn(
+            fvm::laplacian(rAtU(), p) == fvc::div(phiHbyA));
+
+        pEqn.setReference(pRefCell, pRefValue);
+
+        // get the solver performance info such as initial
+        // and final residuals
+        SolverPerformance<scalar> solverP = pEqn.solve();
+
+        this->primalResidualControl<scalar>(solverP, printToScreen, printInterval, "p");
+
+        if (simple.finalNonOrthogonalIter())
+        {
+            phi = phiHbyA - pEqn.flux();
+        }
+    }
+
+    if (printToScreen)
+    {
+#include "continuityErrsPython.H"
+    }
+
+    // Explicitly relax pressure for momentum corrector
+    p.relax();
+
+    // bound p
+    DAUtility::boundVar(allOptions, p, printToScreen);
+
+    // Momentum corrector
+    U = HbyA - rAtU() * fvc::grad(p);
+    // bound U
+    DAUtility::boundVar(allOptions, U, printToScreen);
+    U.correctBoundaryConditions();
+    fvOptions.correct(U);
+}


### PR DESCRIPTION
## Purpose
This PR adds the passive scalar point source as a FvSource class and includes it into a solver , DAMySimpleTFoam.


## Type of change
What types of change is it?


- New feature (non-breaking change which adds functionality)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist

- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation

## Error
Seems like the overloaded function is not working. The calcFvSource function is overloaded with volScalarField and volVectorField as outputs in DAFvSource base class. One would expect that this overloading allows flexibility (as can be seen in DAFvSourceHeatSource where calcFvSource returns a volScalarField. However, on testing, this error is reported
```
[0] 
[0] 
[0] --> FOAM FATAL ERROR: 
[0] calcFvSource not implemented 
 in the child class for 
[0] 
[0]     From function 
[0]     in file DAFvSource/DAFvSource.C at line 98.

```