### PR TITLE
Adding in flag for calculating the heat flux per unit area or for total surface

### DIFF
--- a/src/adjoint/DAObjFunc/DAObjFuncWallHeatFlux.H
+++ b/src/adjoint/DAObjFunc/DAObjFuncWallHeatFlux.H
@@ -50,6 +50,9 @@ protected:
     /// the area of all heat flux patches
     scalar areaSum_ = -9999.0;
 
+    /// if calculating flux per unit area or total, which mode to use
+    word calcMode_;
+
 public:
     TypeName("wallHeatFlux");
     // Constructors


### PR DESCRIPTION
Heat flux is normally calculated per unit area. The "scheme" flag will allow the user to change this. The two options are "byUnitArea" which is how DAFoam normally calculates the heat flux or "total" (the new method) which returns the entire heat transfer value over the surface of interest. If "scheme" is not specified then the default value will be "byUnitArea".