### PR TITLE
wallDistanceMethod Flag Added To daOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ __pycache__
 reg_test_files*
 tests/*.txt
 tests/*.txt.orig
+.vscode/settings.json

--- a/dafoam/pyDAFoam.py
+++ b/dafoam/pyDAFoam.py
@@ -601,6 +601,9 @@ class DAOPTION(object):
             # }
         }
 
+        ## Whether to use OpenFOAMs snGrad() function or to manually compute distance for wall interfaces
+        self.wallDistanceMethod = "default"
+
 
 class PYDAFOAM(object):
     """

--- a/src/adjoint/DAFunction/DAFunctionWallHeatFlux.C
+++ b/src/adjoint/DAFunction/DAFunctionWallHeatFlux.C
@@ -41,7 +41,14 @@ DAFunctionWallHeatFlux::DAFunctionWallHeatFlux(
 {
 
     // check and assign values for scheme and formulation
-    formMode_ = functionDict_.lookupOrDefault<word>("formulation", "default");
+    distanceMode_ = daOption_.getAllOptions().getWord("wallDistanceMethod");
+    if (distanceMode_ != "daCustom" && distanceMode_ != "default")
+    {
+        FatalErrorIn(" ") << "wallDistanceMethod: "
+                          << distanceMode_ << " not supported!"
+                          << " Options are: default and daCustom."
+                          << abort(FatalError);
+    }
     calcMode_ = functionDict_.lookupOrDefault<bool>("byUnitArea", true);
 
     if (mesh_.thisDb().foundObject<DATurbulenceModel>("DATurbulenceModel"))
@@ -146,12 +153,12 @@ scalar DAFunctionWallHeatFlux::calcFunction()
                 if (!wallHeatFluxBf[patchI].coupled())
                 {
                     // use OpenFOAM's snGrad()
-                    if (formMode_ == "default")
+                    if (distanceMode_ == "default")
                     {
                         wallHeatFluxBf[patchI] = Cp_ * alphaEffBf[patchI] * TBf[patchI].snGrad();
                     }
                     // use DAFOAM's custom formulation
-                    else if (formMode_ == "daCustom")
+                    else if (distanceMode_ == "daCustom")
                     {
                         forAll(wallHeatFluxBf[patchI], faceI)
                         {
@@ -164,14 +171,6 @@ scalar DAFunctionWallHeatFlux::calcFunction()
                             scalar dTdz = (T2 - T1) / d;
                             wallHeatFluxBf[patchI][faceI] = Cp_ * alphaEffBf[patchI][faceI] * dTdz;
                         }
-                    }
-                    // error message incase of invalid entry
-                    else
-                    {
-                        FatalErrorIn(" ") << "formulation: "
-                                          << formMode_ << " not supported!"
-                                          << " Options are: default and daCustom."
-                                          << abort(FatalError);
                     }
                 }
             }
@@ -191,12 +190,12 @@ scalar DAFunctionWallHeatFlux::calcFunction()
                 if (!wallHeatFluxBf[patchI].coupled())
                 {
                     // use OpenFOAM's snGrad()
-                    if (formMode_ == "default")
+                    if (distanceMode_ == "default")
                     {
                         wallHeatFluxBf[patchI] = alphaEffBf[patchI] * heBf[patchI].snGrad();
                     }
                     // use DAFOAM's custom formulation
-                    else if (formMode_ == "daCustom")
+                    else if (distanceMode_ == "daCustom")
                     {
                         forAll(wallHeatFluxBf[patchI], faceI)
                         {
@@ -209,14 +208,6 @@ scalar DAFunctionWallHeatFlux::calcFunction()
                             scalar dHedz = (He2 - He1) / d;
                             wallHeatFluxBf[patchI][faceI] = alphaEffBf[patchI][faceI] * dHedz;
                         }
-                    }
-                    // error message incase of invalid entry
-                    else
-                    {
-                        FatalErrorIn(" ") << "formulation: "
-                                          << formMode_ << " not supported!"
-                                          << " Options are: default and daCustom."
-                                          << abort(FatalError);
                     }
                 }
             }
@@ -236,12 +227,12 @@ scalar DAFunctionWallHeatFlux::calcFunction()
             {
 
                 // use OpenFOAM's snGrad()
-                if (formMode_ == "default")
+                if (distanceMode_ == "default")
                 {
                     wallHeatFluxBf[patchI] = k_ * TBf[patchI].snGrad();
                 }
                 // use DAFOAM's custom formulation
-                else if (formMode_ == "daCustom")
+                else if (distanceMode_ == "daCustom")
                 {
                     forAll(wallHeatFluxBf[patchI], faceI)
                     {
@@ -254,14 +245,6 @@ scalar DAFunctionWallHeatFlux::calcFunction()
                         scalar dTdz = (T2 - T1) / d;
                         wallHeatFluxBf[patchI][faceI] = k_ * dTdz;
                     }
-                }
-                // error message incase of invalid entry
-                else
-                {
-                    FatalErrorIn(" ") << "formulation: "
-                                      << formMode_ << " not supported!"
-                                      << " Options are: default and daCustom."
-                                      << abort(FatalError);
                 }
             }
         }

--- a/src/adjoint/DAFunction/DAFunctionWallHeatFlux.H
+++ b/src/adjoint/DAFunction/DAFunctionWallHeatFlux.H
@@ -44,7 +44,7 @@ protected:
     bool calcMode_;
 
     /// if calculating wallHeatFlux by OpenFOAMs snGrad() or DAFOAM's custom (daCustom) formulation
-    word formMode_;
+    word distanceMode_;
 
 public:
     TypeName("wallHeatFlux");

--- a/src/adjoint/DAInput/DAInputThermalCoupling.H
+++ b/src/adjoint/DAInput/DAInputThermalCoupling.H
@@ -55,6 +55,9 @@ protected:
     /// whether this is flow or solid
     word discipline_;
 
+    /// if calculating wallHeatFlux by OpenFOAMs snGrad() or DAFOAM's custom (daCustom) formulation
+    word distanceMode_;
+
 public:
     TypeName("thermalCouplingInput");
     // Constructors

--- a/src/adjoint/DAOutput/DAOutputThermalCoupling.C
+++ b/src/adjoint/DAOutput/DAOutputThermalCoupling.C
@@ -39,7 +39,18 @@ DAOutputThermalCoupling::DAOutputThermalCoupling(
     // NOTE: always sort the patch because the order of the patch element matters in CHT coupling
     sort(patches_);
 
+    // check discipline
     discipline_ = daOption_.getAllOptions().getWord("discipline");
+
+    // check coupling mode and validate
+    distanceMode_ = daOption_.getAllOptions().getWord("wallDistanceMethod");
+    if (distanceMode_ != "daCustom" && distanceMode_ != "default")
+    {
+        FatalErrorIn(" ") << "wallDistanceMethod: "
+                          << distanceMode_ << " not supported!"
+                          << " Options are: default and daCustom."
+                          << abort(FatalError);
+    }
 
     size_ = 0;
     forAll(patches_, idxI)
@@ -81,6 +92,7 @@ void DAOutputThermalCoupling::run(scalarList& output)
     }
 
     // ********* second loop, get the (kappa / d) coefficient
+    scalar deltaCoeffs = 0;
 
     if (discipline_ == "aero")
     {
@@ -111,8 +123,19 @@ void DAOutputThermalCoupling::run(scalarList& output)
                 label patchI = mesh_.boundaryMesh().findPatchID(patchName);
                 forAll(mesh_.boundaryMesh()[patchI], faceI)
                 {
-                    // deltaCoeffs = 1 / d
-                    scalar deltaCoeffs = T.boundaryField()[patchI].patch().deltaCoeffs()[faceI];
+                    if (distanceMode_ == "default")
+                    {
+                        // deltaCoeffs = 1 / d
+                        deltaCoeffs = T.boundaryField()[patchI].patch().deltaCoeffs()[faceI];
+                    }
+                    else if (distanceMode_ == "daCustom")
+                    {
+                        label nearWallCellIndex = mesh_.boundaryMesh()[patchI].faceCells()[faceI];
+                        vector c1 = mesh_.Cf().boundaryField()[patchI][faceI];
+                        vector c2 = mesh_.C()[nearWallCellIndex];
+                        scalar d = mag(c1 - c2);
+                        deltaCoeffs = 1 / d;
+                    }
                     scalar alphaEffBf = alphaEff.boundaryField()[patchI][faceI];
                     // NOTE: we continue to use the counterI from the first loop
                     output[counterI] = Cp * alphaEffBf * deltaCoeffs;
@@ -165,8 +188,19 @@ void DAOutputThermalCoupling::run(scalarList& output)
                 label patchI = mesh_.boundaryMesh().findPatchID(patchName);
                 forAll(mesh_.boundaryMesh()[patchI], faceI)
                 {
-                    // deltaCoeffs = 1 / d
-                    scalar deltaCoeffs = T.boundaryField()[patchI].patch().deltaCoeffs()[faceI];
+                    if (distanceMode_ == "default")
+                    {
+                        // deltaCoeffs = 1 / d
+                        deltaCoeffs = T.boundaryField()[patchI].patch().deltaCoeffs()[faceI];
+                    }
+                    else if (distanceMode_ == "daCustom")
+                    {
+                        label nearWallCellIndex = mesh_.boundaryMesh()[patchI].faceCells()[faceI];
+                        vector c1 = mesh_.Cf().boundaryField()[patchI][faceI];
+                        vector c2 = mesh_.C()[nearWallCellIndex];
+                        scalar d = mag(c1 - c2);
+                        deltaCoeffs = 1 / d;
+                    }
                     scalar alphaEffBf = alphaEff.boundaryField()[patchI][faceI];
                     // NOTE: we continue to use the counterI from the first loop
                     output[counterI] = tmpVal * alphaEffBf * deltaCoeffs;
@@ -195,8 +229,19 @@ void DAOutputThermalCoupling::run(scalarList& output)
             label patchI = mesh_.boundaryMesh().findPatchID(patchName);
             forAll(mesh_.boundaryMesh()[patchI], faceI)
             {
-                // deltaCoeffs = 1 / d
-                scalar deltaCoeffs = T.boundaryField()[patchI].patch().deltaCoeffs()[faceI];
+                if (distanceMode_ == "default")
+                {
+                    // deltaCoeffs = 1 / d
+                    deltaCoeffs = T.boundaryField()[patchI].patch().deltaCoeffs()[faceI];
+                }
+                else if (distanceMode_ == "daCustom")
+                {
+                    label nearWallCellIndex = mesh_.boundaryMesh()[patchI].faceCells()[faceI];
+                    vector c1 = mesh_.Cf().boundaryField()[patchI][faceI];
+                    vector c2 = mesh_.C()[nearWallCellIndex];
+                    scalar d = mag(c1 - c2);
+                    deltaCoeffs = 1 / d;
+                }
                 // NOTE: we continue to use the counterI from the first loop
                 output[counterI] = k * deltaCoeffs;
                 counterI++;

--- a/src/adjoint/DAOutput/DAOutputThermalCoupling.H
+++ b/src/adjoint/DAOutput/DAOutputThermalCoupling.H
@@ -51,6 +51,9 @@ protected:
     /// whether this is flow or solid
     word discipline_;
 
+    /// if calculating wallHeatFlux by OpenFOAMs snGrad() or DAFOAM's custom (daCustom) formulation
+    word distanceMode_;
+
 public:
     TypeName("thermalCouplingOutput");
     // Constructors

--- a/tests/runUnitTests_DACustomCHT.py
+++ b/tests/runUnitTests_DACustomCHT.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python
+"""
+Run Python tests for optimization integration
+"""
+
+import openmdao.api as om
+import os
+import numpy as np
+
+from mpi4py import MPI
+from dafoam import PYDAFOAM
+from testFuncs import *
+from mphys.multipoint import Multipoint
+from dafoam.mphys import DAFoamBuilder
+from funtofem.mphys import MeldThermalBuilder
+from pygeo import geo_utils
+from mphys.scenario_aerothermal import ScenarioAeroThermal
+from pygeo.mphys import OM_DVGEOCOMP
+
+# NOTE: we will test DASimpleFoam and DAHeatTransferFoam for incompressible, compressible, and solid solvers using the daCustom wallDistanceMethod
+
+# ********************
+# incompressible tests
+# ********************
+gcomm = MPI.COMM_WORLD
+os.chdir("./reg_test_files-main/ChannelConjugateHeatV4")
+
+if gcomm.rank == 0:
+    os.system("rm -rf */processor*")
+
+# aero setup
+U0 = 10.0
+
+daOptionsAero = {
+    "designSurfaces": [
+        "hot_air_inner",
+        "hot_air_outer",
+        "hot_air_sides",
+        "cold_air_outer",
+        "cold_air_inner",
+        "cold_air_sides",
+    ],
+    "solverName": "DASimpleFoam",
+    "wallDistanceMethod": "daCustom",
+    "primalMinResTol": 1.0e-12,
+    "primalMinResTolDiff": 1.0e12,
+    "discipline": "aero",
+    "primalBC": {
+        "UHot": {"variable": "U", "patches": ["hot_air_in"], "value": [U0, 0.0, 0.0]},
+        "UCold": {"variable": "U", "patches": ["cold_air_in"], "value": [-U0, 0.0, 0.0]},
+        "useWallFunction": False,
+    },
+    "function": {
+        "HFX": {
+            "type": "wallHeatFlux",
+            "byUnitArea": False,
+            "source": "patchToFace",
+            "patches": ["hot_air_inner"],
+            "scale": 1,
+        },
+    },
+    "adjStateOrdering": "cell",
+    "adjEqnOption": {
+        "gmresRelTol": 1.0e-3,
+        "pcFillLevel": 1,
+        "jacMatReOrdering": "natural",
+        "useNonZeroInitGuess": True,
+        "dynAdjustTol": True,
+    },
+    "normalizeStates": {
+        "U": U0,
+        "p": U0 * U0 / 2.0,
+        "nuTilda": 1e-3,
+        "T": 300,
+        "phi": 1.0,
+    },
+    "inputInfo": {
+        "aero_vol_coords": {"type": "volCoord", "components": ["solver", "function"]},
+        "T_convect": {
+            "type": "thermalCouplingInput",
+            "patches": ["hot_air_inner", "cold_air_outer"],
+            "components": ["solver"],
+        },
+    },
+    "outputInfo": {
+        "q_convect": {
+            "type": "thermalCouplingOutput",
+            "patches": ["hot_air_inner", "cold_air_outer"],
+            "components": ["thermalCoupling"],
+        },
+    },
+}
+
+daOptionsThermal = {
+    "designSurfaces": ["channel_outer", "channel_inner", "channel_sides"],
+    "solverName": "DAHeatTransferFoam",
+    "wallDistanceMethod": "daCustom",
+    "primalMinResTol": 1.0e-12,
+    "primalMinResTolDiff": 1.0e12,
+    "discipline": "thermal",
+    "function": {
+        "HF_INNER": {
+            "type": "wallHeatFlux",
+            "byUnitArea": False,
+            "source": "patchToFace",
+            "patches": ["channel_inner"],
+            "scale": 1,
+        },
+    },
+    "adjStateOrdering": "cell",
+    "adjEqnOption": {
+        "gmresRelTol": 1.0e-3,
+        "pcFillLevel": 1,
+        "jacMatReOrdering": "natural",
+        "useNonZeroInitGuess": True,
+        "dynAdjustTol": True,
+    },
+    "normalizeStates": {
+        "T": 300.0,
+    },
+    "inputInfo": {
+        "thermal_vol_coords": {"type": "volCoord", "components": ["solver", "function"]},
+        "q_conduct": {
+            "type": "thermalCouplingInput",
+            "patches": ["channel_outer", "channel_inner"],
+            "components": ["solver"],
+        },
+    },
+    "outputInfo": {
+        "T_conduct": {
+            "type": "thermalCouplingOutput",
+            "patches": ["channel_outer", "channel_inner"],
+            "components": ["thermalCoupling"],
+        },
+    },
+}
+
+# Mesh deformation setup
+meshOptions = {
+    "gridFile": os.getcwd(),
+    "fileType": "OpenFOAM",
+    # point and normal for the symmetry plane
+    "symmetryPlanes": [],
+}
+
+
+class Top(Multipoint):
+    def setup(self):
+
+        dafoam_builder_aero = DAFoamBuilder(daOptionsAero, meshOptions, scenario="aerothermal", run_directory="aero")
+        dafoam_builder_aero.initialize(self.comm)
+
+        dafoam_builder_thermal = DAFoamBuilder(
+            daOptionsThermal, meshOptions, scenario="aerothermal", run_directory="thermal"
+        )
+        dafoam_builder_thermal.initialize(self.comm)
+
+        thermalxfer_builder = MeldThermalBuilder(dafoam_builder_aero, dafoam_builder_thermal, n=1, beta=0.5)
+        thermalxfer_builder.initialize(self.comm)
+
+        # add the design variable component to keep the top level design variables
+        self.add_subsystem("dvs", om.IndepVarComp(), promotes=["*"])
+
+        # add the mesh component
+        self.add_subsystem("mesh_aero", dafoam_builder_aero.get_mesh_coordinate_subsystem())
+        self.add_subsystem("mesh_thermal", dafoam_builder_thermal.get_mesh_coordinate_subsystem())
+
+        # add the geometry component (FFD). Note that the aero and thermal use the exact same FFD file
+        self.add_subsystem("geometry_aero", OM_DVGEOCOMP(file="aero/FFD/channelFFD.xyz", type="ffd"))
+        self.add_subsystem("geometry_thermal", OM_DVGEOCOMP(file="aero/FFD/channelFFD.xyz", type="ffd"))
+
+        # add a scenario (flow condition) for optimization, we pass the builder
+        # to the scenario to actually run the flow and adjoint
+        self.mphys_add_scenario(
+            "scenario",
+            ScenarioAeroThermal(
+                aero_builder=dafoam_builder_aero,
+                thermal_builder=dafoam_builder_thermal,
+                thermalxfer_builder=thermalxfer_builder,
+            ),
+            om.NonlinearBlockGS(maxiter=20, iprint=2, use_aitken=True, rtol=1e-8, atol=1e-14),
+            om.LinearBlockGS(maxiter=20, iprint=2, use_aitken=True, rtol=1e-8, atol=1e-14),
+        )
+
+        # need to manually connect the x_aero0 between the mesh and geometry components
+        self.connect("mesh_aero.x_aero0", "geometry_aero.x_aero_in")
+        self.connect("geometry_aero.x_aero0", "scenario.x_aero")
+
+        self.connect("mesh_thermal.x_thermal0", "geometry_thermal.x_thermal_in")
+        self.connect("geometry_thermal.x_thermal0", "scenario.x_thermal")
+
+    def configure(self):
+
+        super().configure()
+
+        # get the surface coordinates from the mesh component
+        points_aero = self.mesh_aero.mphys_get_surface_mesh()
+        points_thermal = self.mesh_thermal.mphys_get_surface_mesh()
+
+        # add pointset to the geometry component
+        self.geometry_aero.nom_add_discipline_coords("aero", points_aero)
+        self.geometry_thermal.nom_add_discipline_coords("thermal", points_thermal)
+
+        # geometry setup
+        pts = self.geometry_aero.DVGeo.getLocalIndex(0)
+        dir_y = np.array([0.0, 1.0, 0.0])
+        shapes = []
+        shapes.append({pts[9, 0, 0]: dir_y, pts[9, 0, 1]: dir_y})
+        self.geometry_aero.nom_addShapeFunctionDV(dvName="shape", shapes=shapes)
+        self.geometry_thermal.nom_addShapeFunctionDV(dvName="shape", shapes=shapes)
+
+        # add the design variables to the dvs component's output
+        self.dvs.add_output("shape", val=np.array([0]))
+        # manually connect the dvs output to the geometry
+        self.connect("shape", "geometry_aero.shape")
+        self.connect("shape", "geometry_thermal.shape")
+
+        # define the design variables to the top level
+        self.add_design_var("shape", lower=-1, upper=1, scaler=1.0)
+
+        # add objective and constraints to the top level
+        self.add_objective("scenario.aero_post.HFX", scaler=1.0)
+
+
+prob = om.Problem()
+prob.model = Top()
+
+prob.setup(mode="rev")
+prob.run_model()
+
+HFX = prob.get_val("scenario.aero_post.HFX")[0]
+print("HFX:", HFX)
+if (abs(HFX - 180000.0) / (HFX + 1e-16)) > 1e-6:
+    print("DAHeatTransferFoam test failed for DACustomCHT!")
+    exit(1)
+else:
+    print("DAHeatTransferFoam test passed for DACustomCHT!")
+
+
+# ********************
+# compressible tests
+# ********************
+os.chdir("./reg_test_files-main/ConvergentChannel")
+
+if gcomm.rank == 0:
+    os.system("rm -rf 0/* processor* *.bin")
+    os.system("cp -r 0.compressible/* 0/")
+    os.system("cp -r system.subsonic/* system/")
+    os.system("cp -r constant/turbulenceProperties.sa constant/turbulenceProperties")
+
+# aero setup
+U0 = 100.0
+
+daOptions = {
+    "solverName": "DARhoSimpleFoam",
+    "wallDistanceMethod": "daCustom",
+    "primalMinResTol": 1.0e-12,
+    "primalMinResTolDiff": 1e4,
+    "printDAOptions": False,
+    "primalBC": {
+        "U0": {"variable": "U", "patches": ["inlet"], "value": [U0, 0.0, 0.0]},
+        "T0": {"variable": "T", "patches": ["inlet"], "value": [310.0]},
+        "p0": {"variable": "p", "patches": ["outlet"], "value": [101325.0]},
+        "useWallFunction": True,
+    },
+    "function": {
+        "HFX": {
+            "type": "wallHeatFlux",
+            "byUnitArea": False,
+            "source": "patchToFace",
+            "patches": ["walls"],
+            "scale": 1.0,
+        },
+    },
+}
+
+DASolver = PYDAFOAM(options=daOptions, comm=gcomm)
+DASolver()
+
+funcs = {}
+DASolver.evalFunctions(funcs)
+
+diff = abs(8967.626339018574 - funcs["HFX"]) / 8967.626339018574
+if diff > 1e-10:
+    if gcomm.rank == 0:
+        print("DAFunction comp test failed for DACustomCHT")
+    exit(1)
+else:
+    if gcomm.rank == 0:
+        print("DAFunction comp test passed for DACustomCHT!")

--- a/tests/runUnitTests_DACustomCHT.py
+++ b/tests/runUnitTests_DACustomCHT.py
@@ -240,6 +240,7 @@ else:
 # ********************
 # compressible tests
 # ********************
+os.chdir("../ConvergentChannel")
 if gcomm.rank == 0:
     os.system("rm -rf 0/* processor* *.bin")
     os.system("cp -r 0.compressible/* 0/")

--- a/tests/runUnitTests_DACustomCHT.py
+++ b/tests/runUnitTests_DACustomCHT.py
@@ -240,8 +240,6 @@ else:
 # ********************
 # compressible tests
 # ********************
-os.chdir("./reg_test_files-main/ConvergentChannel")
-
 if gcomm.rank == 0:
     os.system("rm -rf 0/* processor* *.bin")
     os.system("cp -r 0.compressible/* 0/")

--- a/tests/runUnitTests_DAFunction.py
+++ b/tests/runUnitTests_DAFunction.py
@@ -65,14 +65,6 @@ daOptions = {
             "patches": ["walls"],
             "scale": 1.0,
         },
-        "HFX_custom": {
-            "type": "wallHeatFlux",
-            "byUnitArea": False,
-            "formulation": "daCustom",
-            "source": "patchToFace",
-            "patches": ["walls"],
-            "scale": 1.0,
-        },
         "PMean": {
             "type": "patchMean",
             "source": "patchToFace",
@@ -234,7 +226,6 @@ funcs_ref = {
     "CMZ": 7.1768354637131795,
     "TP1": 2.5561992647012914,
     "HFX": 8.20332195479527,
-    "HFX_custom": 28.645216245520146,
     "PMean": 77.80996323506456,
     "UMean": 15.469850053816028,
     "skewness": 1.3140396235456926,
@@ -299,14 +290,6 @@ daOptions = {
             "patches": ["walls"],
             "scale": 1.0,
         },
-        "HFX_custom": {
-            "type": "wallHeatFlux",
-            "byUnitArea": False,
-            "formulation": "daCustom",
-            "source": "patchToFace",
-            "patches": ["walls"],
-            "scale": 1.0,
-        },
         "TTR": {
             "type": "totalTemperatureRatio",
             "source": "patchToFace",
@@ -354,7 +337,6 @@ if gcomm.rank == 0:
 
 funcs_ref = {
     "HFX": 2564.397361965973,
-    "HFX_custom": 8967.626339020631,
     "TTR": 1.0002129350727795,
     "MFR": 128.2374484095998,
     "TPR": 0.9933893131111589,


### PR DESCRIPTION
I added the flag "wallDistanceMethod" to daOptions to use the custom/manual distance calculation. The byUnitArea option remains in the function dictionary. Additionally, incompressible, compressible, and solid unit tests have been added which test the wallDistanceMethod flag as well as using byUnitArea: False. All tests for wallDistanceMethod and byUnitArea have been moved to runUnitTests_DACustomCHT.py.
