### PR TITLE
Cd std

### DIFF
--- a/dafoam/pyDAFoam.py
+++ b/dafoam/pyDAFoam.py
@@ -82,9 +82,9 @@ class DAOPTION(object):
         ## The convergence function std oscillation tolerance for the primal solver.
         ## tol: the tolerance of the function oscillation standard deviation, -1 means it is deactivated
         ## funcName: which function to use to calculate the std.
-        ## nSteps: how many (latest) function samples/steps to use for calculating the std, here
-        ##          100 means we always use the last 100 step's function values to compute the std
-        self.primalFuncStdTol = {"tol": -1.0, "funcName": "CD", "nSteps": 100}
+        ## nStepsFrac: the fraction of elapsed iterations to use as the std window, here
+        ##          0.2 means we always use the last 20% of elapsed iterations to compute the std
+        self.primalFuncStdTol = {"tol": -1.0, "funcName": "CD", "nStepsFrac": 0.2}
 
         ## The boundary condition for primal solution. The keys should include "variable", "patch",
         ## and "value". For turbulence variable, one can also set "useWallFunction" [bool].

--- a/src/adjoint/DASolver/DASolver.C
+++ b/src/adjoint/DASolver/DASolver.C
@@ -98,7 +98,7 @@ DASolver::DASolver(
     printIntervalUnsteady_ = daOptionPtr_->getOption<label>("printIntervalUnsteady");
     primalFuncStdTol_ = daOptionPtr_->getSubDictOption<scalar>("primalFuncStdTol", "tol");
     primalFuncStdName_ = daOptionPtr_->getSubDictOption<word>("primalFuncStdTol", "funcName");
-    primalFuncStdSteps_ = daOptionPtr_->getSubDictOption<label>("primalFuncStdTol", "nSteps");
+    primalFuncStdFrac_ = daOptionPtr_->getSubDictOption<scalar>("primalFuncStdTol", "nStepsFrac");
 
     // if inputInto has unsteadyField, we need to initial GlobalVar::inputFieldUnsteady here
     this->initInputFieldUnsteady();
@@ -222,7 +222,8 @@ void DASolver::calcFuncStd()
     label timeIndex = runTimePtr_->timeIndex();
     label listIndex = timeIndex - 1;
     label funcIdx = this->getFunctionListIndex(primalFuncStdName_);
-    label startIdx = max(0, listIndex - primalFuncStdSteps_ + 1);
+    label window = max(1, round(primalFuncStdFrac_ * scalar(listIndex + 1)));
+    label startIdx = max(0, listIndex - window + 1);
 
     scalar mean = 0.0;
     label nActualSteps = listIndex - startIdx + 1;

--- a/src/adjoint/DASolver/DASolver.C
+++ b/src/adjoint/DASolver/DASolver.C
@@ -222,7 +222,7 @@ void DASolver::calcFuncStd()
     label timeIndex = runTimePtr_->timeIndex();
     label listIndex = timeIndex - 1;
     label funcIdx = this->getFunctionListIndex(primalFuncStdName_);
-    label window = max(1, round(primalFuncStdFrac_ * scalar(listIndex + 1)));
+    label window = max(2, round(primalFuncStdFrac_ * scalar(listIndex + 1)));
     label startIdx = max(0, listIndex - window + 1);
 
     scalar mean = 0.0;

--- a/src/adjoint/DASolver/DASolver.H
+++ b/src/adjoint/DASolver/DASolver.H
@@ -153,8 +153,8 @@ protected:
     /// the function name for the std tolerance
     word primalFuncStdName_ = "CD";
 
-    /// the number of last steps to compute std
-    label primalFuncStdSteps_ = 100;
+    /// the fraction of elapsed iterations to use as the std window
+    scalar primalFuncStdFrac_ = 0.2;
 
     /// the std of a function, default to be -1
     scalar funcStd_ = 1e16;

--- a/tests/refs/DAFoam_Test_DATurboFoamSubsonicRef.txt
+++ b/tests/refs/DAFoam_Test_DATurboFoamSubsonicRef.txt
@@ -6,9 +6,9 @@ Dictionary Key: CMZ
 Dictionary Key: shape-Adjoint
 @value         0.5765086191481391 1e-08 1e-12
 Dictionary Key: shape-FD
-@value         0.5845217349417453 1e-08 1e-12
+@value         0.5845217497507065 1e-08 1e-12
 Dictionary Key: TPR
 Dictionary Key: shape-Adjoint
 @value        -0.0581044980394885 1e-08 1e-12
 Dictionary Key: shape-FD
-@value        -0.0545726753443887 1e-08 1e-12
+@value        -0.0545726708860457 1e-08 1e-12

--- a/tests/refs/DAFoam_Test_DATurboFoamSubsonicRef.txt
+++ b/tests/refs/DAFoam_Test_DATurboFoamSubsonicRef.txt
@@ -6,9 +6,9 @@ Dictionary Key: CMZ
 Dictionary Key: shape-Adjoint
 @value         0.5765086191481391 1e-08 1e-12
 Dictionary Key: shape-FD
-@value         0.5845217497507065 1e-08 1e-12
+@value         0.5845217598382533 1e-08 1e-12
 Dictionary Key: TPR
 Dictionary Key: shape-Adjoint
 @value        -0.0581044980394885 1e-08 1e-12
 Dictionary Key: shape-FD
-@value        -0.0545726708860457 1e-08 1e-12
+@value        -0.0545726654409009 1e-08 1e-12

--- a/tests/runRegTests_DATurboFoamSubsonic.py
+++ b/tests/runRegTests_DATurboFoamSubsonic.py
@@ -36,7 +36,8 @@ daOptions = {
     "primalMinResTol": 1.0e-12,
     "primalMinResTolDiff": 1e4,
     "useAD": {"mode": "reverse", "seedIndex": 0, "dvName": "shape"},
-    "primalFuncStdTol": {"tol": 3e-12, "funcName": "TPR", "nSteps": 50},
+    #"primalFuncStdTol": {"tol": 3e-12, "funcName": "TPR", "nSteps": 50},
+    "primalFuncStdTol": {"tol": 3e-12, "funcName": "TPR", "nStepsFrac": 0.108},
     "primalBC": {
         "U0": {"variable": "U", "patches": ["inlet"], "value": [0.0, 0.0, 100.0]},
         "T0": {"variable": "T", "patches": ["inlet"], "value": [300.0]},

--- a/tests/runRegTests_DATurboFoamSubsonic.py
+++ b/tests/runRegTests_DATurboFoamSubsonic.py
@@ -36,7 +36,6 @@ daOptions = {
     "primalMinResTol": 1.0e-12,
     "primalMinResTolDiff": 1e4,
     "useAD": {"mode": "reverse", "seedIndex": 0, "dvName": "shape"},
-    #"primalFuncStdTol": {"tol": 3e-12, "funcName": "TPR", "nSteps": 50},
     "primalFuncStdTol": {"tol": 3e-12, "funcName": "TPR", "nStepsFrac": 0.108},
     "primalBC": {
         "U0": {"variable": "U", "patches": ["inlet"], "value": [0.0, 0.0, 100.0]},


### PR DESCRIPTION
## Purpose
Uses the last 20% (or user-specified) of the iterations to calculate the std instead of using a fixed nStep

## Type of change
nStep = 50 -> nStepFrac = 0.2
Regression test for DATurboFoamSubsonic is adjusted accordingly (minor FD changes only)

## Testing
N/A

## Checklist
_Put an `x` in the boxes that apply._

- [x ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
