### PR TITLE
Fixed primalBC and DAInput issue for Hisa.

### DIFF
--- a/src/adjoint/DAField/DAField.C
+++ b/src/adjoint/DAField/DAField.C
@@ -806,6 +806,68 @@ void DAField::setPrimalBoundaryConditions(const label printInfo)
 
             continue;
         }
+        else if (bcKey == "charFarFieldBC")
+        {
+            // set characteristic far field boundary conditions for DAHisaFoam,
+            // we assume the input would be a list of 5 scalars: [Ux, Uy, Uz, p, T]
+            scalarList bcVals;
+            bcDict.readEntry<scalarList>("charFarFieldBC", bcVals);
+            scalar Ux0 = bcVals[0];
+            scalar Uy0 = bcVals[1];
+            scalar Uz0 = bcVals[2];
+            scalar p0 = bcVals[3];
+            scalar T0 = bcVals[4];
+
+            volVectorField& U = db.lookupObjectRef<volVectorField>("U");
+            volScalarField& p = db.lookupObjectRef<volScalarField>("p");
+            volScalarField& T = db.lookupObjectRef<volScalarField>("T");
+
+            // assign the BC for U, p, and T. NOTE: we need to set BC for all these three variables
+            // because their BC values are inter-coupled in the characteristic far field BC implementation
+            forAll(mesh_.boundaryMesh(), patchI)
+            {
+                if (U.boundaryFieldRef()[patchI].type() == "characteristicFarfieldVelocity")
+                {
+                    // set U
+                    forAll(U.boundaryFieldRef()[patchI], faceI)
+                    {
+                        U.boundaryFieldRef()[patchI][faceI] = vector(Ux0, Uy0, Uz0);
+                    }
+                    // set characteristicRef
+                    characteristicBase& base = refCast<characteristicBase>(U.boundaryFieldRef()[patchI]);
+                    base.URef() = vector(Ux0, Uy0, Uz0);
+                    base.pRef() = p0;
+                    base.TRef() = T0;
+                }
+                if (p.boundaryFieldRef()[patchI].type() == "characteristicFarfieldPressure")
+                {
+                    // set p
+                    forAll(p.boundaryFieldRef()[patchI], faceI)
+                    {
+                        p.boundaryFieldRef()[patchI][faceI] = p0;
+                    }
+                    // set characteristicRef
+                    characteristicBase& base = refCast<characteristicBase>(p.boundaryFieldRef()[patchI]);
+                    base.URef() = vector(Ux0, Uy0, Uz0);
+                    base.pRef() = p0;
+                    base.TRef() = T0;
+                }
+                if (T.boundaryFieldRef()[patchI].type() == "characteristicFarfieldTemperature")
+                {
+                    // set T
+                    forAll(T.boundaryFieldRef()[patchI], faceI)
+                    {
+                        T.boundaryFieldRef()[patchI][faceI] = T0;
+                    }
+                    // set characteristicRef
+                    characteristicBase& base = refCast<characteristicBase>(T.boundaryFieldRef()[patchI]);
+                    base.URef() = vector(Ux0, Uy0, Uz0);
+                    base.pRef() = p0;
+                    base.TRef() = T0;
+                }
+            }
+            continue;
+        }
 
         dictionary bcSubDict = bcDict.subDict(bcKey);
 
@@ -889,23 +951,10 @@ void DAField::setPrimalBoundaryConditions(const label printInfo)
                             refCast<characteristicBase>(state.boundaryFieldRef()[patchI]);
                         stateBase.pRef() = value[0];
                     }
-                    else if (state.boundaryFieldRef()[patchI].type() == "characteristicFarfieldTemperature")
-                    {
-                        // set value
-                        forAll(state.boundaryFieldRef()[patchI], faceI)
-                        {
-                            state.boundaryFieldRef()[patchI][faceI] = value[0];
-                        }
-                        // set TRef
-                        characteristicBase& stateBase =
-                            refCast<characteristicBase>(state.boundaryFieldRef()[patchI]);
-                        stateBase.TRef() = value[0];
-                    }
                     else
                     {
                         FatalErrorIn("") << "only support fixedValues, inletOutlet, "
-                                         << "outletInlet, fixedGradient, "
-                                         << "characteristicFarfieldPressure, and characteristicFarfieldTemperature!"
+                                         << "outletInlet, fixedGradient"
                                          << abort(FatalError);
                     }
                 }
@@ -957,18 +1006,6 @@ void DAField::setPrimalBoundaryConditions(const label printInfo)
                             refCast<mixedFvPatchField<vector>>(state.boundaryFieldRef()[patchI]);
                         inletOutletPatch.refValue() = valVec;
                     }
-                    else if (state.boundaryFieldRef()[patchI].type() == "characteristicFarfieldVelocity")
-                    {
-                        // set value
-                        forAll(state.boundaryFieldRef()[patchI], faceI)
-                        {
-                            state.boundaryFieldRef()[patchI][faceI] = valVec;
-                        }
-                        // set URef
-                        characteristicBase& stateBase =
-                            refCast<characteristicBase>(state.boundaryFieldRef()[patchI]);
-                        stateBase.URef() = valVec;
-                    }
                     else if (state.boundaryFieldRef()[patchI].type() == "fixedGradient")
                     {
                         fixedGradientFvPatchField<vector>& patchBC =
@@ -984,8 +1021,7 @@ void DAField::setPrimalBoundaryConditions(const label printInfo)
                     else
                     {
                         FatalErrorIn("") << "only support fixedValues, inletOutlet, "
-                                         << "fixedGradient, tractionDisplacement, "
-                                         << "characteristicFarfieldVelocity!"
+                                         << "fixedGradient, tractionDisplacement"
                                          << abort(FatalError);
                     }
                 }

--- a/src/adjoint/DAInput/DAInputPatchVelocity.C
+++ b/src/adjoint/DAInput/DAInputPatchVelocity.C
@@ -69,13 +69,16 @@ void DAInputPatchVelocity::run(const scalarList& input)
     label flowAxisIndex = axisIndices[flowAxis];
     label normalAxisIndex = axisIndices[normalAxis];
 
-    volVectorField& U = const_cast<volVectorField&>(mesh_.thisDb().lookupObject<volVectorField>("U"));
+    volVectorField& U = mesh_.thisDb().lookupObjectRef<volVectorField>("U");
+    volScalarField& p = mesh_.thisDb().lookupObjectRef<volScalarField>("p");
+    volScalarField& T = mesh_.thisDb().lookupObjectRef<volScalarField>("T");
 
     scalar aoaRad = input[1] * constant::mathematical::pi / 180.0;
     scalar UxNew = UMag * cos(aoaRad);
     scalar UyNew = UMag * sin(aoaRad);
 
     // now we assign UxNew and UyNew to the U patches
+    label hasCharFarFieldBC = 0;
     forAll(patchNames, idxI)
     {
         word patchName = patchNames[idxI];
@@ -104,21 +107,42 @@ void DAInputPatchVelocity::run(const scalarList& input)
             else if (U.boundaryFieldRef()[patchI].type() == "characteristicFarfieldVelocity")
             {
                 // set URef value
-                characteristicBase& stateBase =
+                characteristicBase& baseU =
                     refCast<characteristicBase>(U.boundaryFieldRef()[patchI]);
 
-                stateBase.URef()[flowAxisIndex] = UxNew;
-                stateBase.URef()[normalAxisIndex] = UyNew;
+                baseU.URef()[flowAxisIndex] = UxNew;
+                baseU.URef()[normalAxisIndex] = UyNew;
+
+                // IMPORTANT: for char far field BC, we also need to update BC for p and T
+                // because U, p, and T BCs are inter-coupled in the char far field BC implementation.
+                characteristicBase& baseP =
+                    refCast<characteristicBase>(p.boundaryFieldRef()[patchI]);
+                baseP.URef()[flowAxisIndex] = UxNew;
+                baseP.URef()[normalAxisIndex] = UyNew;
+
+                characteristicBase& baseT =
+                    refCast<characteristicBase>(T.boundaryFieldRef()[patchI]);
+                baseT.URef()[flowAxisIndex] = UxNew;
+                baseT.URef()[normalAxisIndex] = UyNew;
+
+                hasCharFarFieldBC = 1;
             }
             else
             {
                 FatalErrorIn("DAInputPatchVelocity::run")
-                    << "patch type not valid! only support fixedValue or inletOutlet"
+                    << "patch type not valid! only support fixedValue, inletOutlet, or characteristicFarfieldVelocity"
                     << exit(FatalError);
             }
         }
     }
     U.correctBoundaryConditions();
+
+    reduce(hasCharFarFieldBC, sumOp<label>());
+    if (hasCharFarFieldBC > 0)
+    {
+        p.correctBoundaryConditions();
+        T.correctBoundaryConditions();
+    }
 }
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/src/adjoint/DAResidual/DAResidualHisaFoam.C
+++ b/src/adjoint/DAResidual/DAResidualHisaFoam.C
@@ -294,6 +294,9 @@ void DAResidualHisaFoam::updateIntermediateVariables()
     rho_.correctBoundaryConditions();
     rhoU_.boundaryFieldRef() = rho_.boundaryField() * U_.boundaryField();
     rhoE_.boundaryFieldRef() = rho_.boundaryField() * (he_.boundaryField() - eZero.boundaryField() + 0.5 * magSqr(U_.boundaryField()));
+
+    // Update the fluxes because some characteristics based BCs use the fluxes to update the far field BCs
+    fluxScheme_.calcFlux(phi_, phiUp_, phiEp_, Up_);
 }
 
 void DAResidualHisaFoam::correctBoundaryConditions()

--- a/src/adjoint/DASolver/DASolver.C
+++ b/src/adjoint/DASolver/DASolver.C
@@ -3476,6 +3476,13 @@ void DASolver::setPrimalBoundaryConditions(const label printInfo)
             Info << "Setting up primal boundary conditions based on pyOptions: " << endl;
         }
         daFieldPtr_->setPrimalBoundaryConditions(printInfo);
+
+        // Update the BC and intermediate variables for DAHisaFoam.
+        // We need to update rho, rhoU, and rhoU right after we updating primitive vars.
+        if (daOptionPtr_->getAllOptions().getWord("solverName") == "DAHisaFoam")
+        {
+            this->updateStateBoundaryConditions();
+        }
     }
 }
 
@@ -3497,6 +3504,13 @@ void DASolver::setPrimalInitialConditions(const label printInfo)
             Info << "Setting up primal initial conditions based on pyOptions: " << endl;
         }
         daFieldPtr_->setPrimalInitialConditions(printInfo);
+
+        // Update the BC and intermediate variables for DAHisaFoam.
+        // We need to update rho, rhoU, and rhoU right after we updating primitive vars.
+        if (daOptionPtr_->getAllOptions().getWord("solverName") == "DAHisaFoam")
+        {
+            this->updateStateBoundaryConditions();
+        }
     }
 }
 

--- a/tests/refs/DAFoam_Test_DAHisaFoamRef.txt
+++ b/tests/refs/DAFoam_Test_DAHisaFoamRef.txt
@@ -1,14 +1,13 @@
-Dictionary Key: CD_AUSM
-@value     39597.5038491029336001 1e-10 1e-12
 Dictionary Key: CD_JST
-@value     39456.4802372363119503 1e-10 1e-12
-Dictionary Key: CD_AUSM
-Dictionary Key: shape-Adjoint
-@value      1157.1203156094532005 1e-08 1e-12
-Dictionary Key: shape-FD
-@value      1145.8576716759707779 1e-08 1e-12
+@value     39456.4802375051076524 1e-10 1e-12
 Dictionary Key: CD_JST
+Dictionary Key: patchV-Adjoint
+@value       111.0393959161382185 1e-08 1e-12
+@value        -5.7509534221872416 1e-08 1e-12
+Dictionary Key: patchV-FD
+@value       111.0521217058412731 1e-08 1e-12
+@value        -5.7506649158895016 1e-08 1e-12
 Dictionary Key: shape-Adjoint
-@value       888.6714499220936432 1e-08 1e-12
+@value       888.6714424092148192 1e-08 1e-12
 Dictionary Key: shape-FD
-@value       861.2412356750573963 1e-08 1e-12
+@value       861.2410497993696481 1e-08 1e-12

--- a/tests/runRegTests_DAHisaFoam.py
+++ b/tests/runRegTests_DAHisaFoam.py
@@ -37,9 +37,7 @@ daOptions = {
     "useAD": {"mode": "reverse", "seedIndex": 0, "dvName": "shape"},
     "primalInitCondition": {"U": [U0, 0.0, 0.0], "p": p0, "T": T0},
     "primalBC": {
-        "U0": {"variable": "U", "patches": ["inlet", "outlet"], "value": [U0, 0.0, 0.0]},
-        "p0": {"variable": "p", "patches": ["inlet", "outlet"], "value": [p0]},
-        "T0": {"variable": "T", "patches": ["inlet", "outlet"], "value": [T0]},
+        "charFarFieldBC": [U0, 0.0, 0.0, p0, T0],
         "useWallFunction": False,
     },
     "function": {
@@ -56,6 +54,13 @@ daOptions = {
     "normalizeStates": {"U": U0, "p": 101325, "T": 300.0, "nuTilda": 1e-3},
     "inputInfo": {
         "aero_vol_coords": {"type": "volCoord", "components": ["solver", "function"]},
+        "patchV": {
+            "type": "patchVelocity",
+            "patches": ["inlet"],
+            "flowAxis": "x",
+            "normalAxis": "y",
+            "components": ["solver", "function"],
+        },
     },
 }
 
@@ -109,11 +114,14 @@ class Top(Multipoint):
 
         # add the design variables to the dvs component's output
         self.dvs.add_output("shape", val=np.zeros(1))
+        self.dvs.add_output("patchV", val=np.array([U0, 0.0]))
         # manually connect the dvs output to the geometry and cruise
         self.connect("shape", "geometry.shape")
+        self.connect("patchV", "cruise.patchV")
 
         # define the design variables to the top level
         self.add_design_var("shape", lower=-10.0, upper=10.0, scaler=1.0)
+        self.add_design_var("patchV", lower=[U0, 0.0], upper=[U0, 10.0], scaler=1.0)
 
         # add constraints and the objective
         self.add_objective("cruise.aero_post.CD", scaler=1.0)
@@ -132,7 +140,7 @@ om.n2(prob, show_browser=False, outfile="mphys_aero.html")
 prob.run_model()
 results = prob.check_totals(
     of=["cruise.aero_post.CD"],
-    wrt=["shape"],
+    wrt=["shape", "patchV"],
     compact_print=True,
     step=1e-2,
     form="central",
@@ -146,41 +154,7 @@ if gcomm.rank == 0:
     derivDict["CD_JST"] = {}
     derivDict["CD_JST"]["shape-Adjoint"] = results[("cruise.aero_post.CD", "shape")]["J_fwd"][0]
     derivDict["CD_JST"]["shape-FD"] = results[("cruise.aero_post.CD", "shape")]["J_fd"][0]
-
-
-# ******* test AUSMPlusUp *******
-if gcomm.rank == 0:
-    os.system("rm -rf 0/* processor* *.bin")
-    os.system("cp -r 0.hisa/* 0/")
-    os.system("cp -r system.hisa/* system/")
-    os.system("cp -r constant/turbulenceProperties.sa constant/turbulenceProperties")
-    replace_text_in_file("system/fvSchemes", "meshWave;", "meshWaveFrozen;")
-    replace_text_in_file("system/fvSchemes", "fluxScheme           JST;", "fluxScheme           AUSMPlusUp;")
-
-
-daOptions["adjEqnOption"]["hisaForceJSTFlux"] = 0
-
-prob = om.Problem()
-prob.model = Top()
-
-prob.setup(mode="rev")
-om.n2(prob, show_browser=False, outfile="mphys_aero.html")
-
-# verify the total derivatives against the finite-difference
-prob.run_model()
-results = prob.check_totals(
-    of=["cruise.aero_post.CD"],
-    wrt=["shape"],
-    compact_print=True,
-    step=1e-2,
-    form="central",
-    step_calc="abs",
-)
-
-if gcomm.rank == 0:
-    funcDict["CD_AUSM"] = prob.get_val("cruise.aero_post.CD")
-    derivDict["CD_AUSM"] = {}
-    derivDict["CD_AUSM"]["shape-Adjoint"] = results[("cruise.aero_post.CD", "shape")]["J_fwd"][0]
-    derivDict["CD_AUSM"]["shape-FD"] = results[("cruise.aero_post.CD", "shape")]["J_fd"][0]
+    derivDict["CD_JST"]["patchV-Adjoint"] = results[("cruise.aero_post.CD", "patchV")]["J_fwd"][0]
+    derivDict["CD_JST"]["patchV-FD"] = results[("cruise.aero_post.CD", "patchV")]["J_fd"][0]
     reg_write_dict(funcDict, 1e-10, 1e-12)
     reg_write_dict(derivDict, 1e-8, 1e-12)


### PR DESCRIPTION
The main problem was that the charBC in Hisa coupled U, T, and p,, so we need to update URef, pRef, and TRef for all these vars. Plus, Hisa uses rho, rhoU, and rhoE, so we need to call updateIntermediateVars after we update the primitive vars.