### PR TITLE
[codex] Add multi-function primal std convergence

### DIFF
--- a/dafoam/pyDAFoam.py
+++ b/dafoam/pyDAFoam.py
@@ -82,9 +82,12 @@ class DAOPTION(object):
         ## The convergence function std oscillation tolerance for the primal solver.
         ## tol: the tolerance of the function oscillation standard deviation, -1 means it is deactivated
         ## funcName: which function to use to calculate the std.
+        ## funcNames: optional list of functions to monitor. If set, all function stds must satisfy
+        ##          their tolerances before convergence. This is useful for force-flat checks on CD and CL.
+        ## tols: optional list of tolerances matching funcNames. A single value is applied to all funcNames.
         ## nStepsFrac: the fraction of elapsed iterations to use as the std window, here
         ##          0.2 means we always use the last 20% of elapsed iterations to compute the std
-        self.primalFuncStdTol = {"tol": -1.0, "funcName": "CD", "nStepsFrac": 0.2}
+        self.primalFuncStdTol = {"tol": -1.0, "funcName": "CD", "funcNames": [], "tols": [], "nStepsFrac": 0.2}
 
         ## The boundary condition for primal solution. The keys should include "variable", "patch",
         ## and "value". For turbulence variable, one can also set "useWallFunction" [bool].

--- a/src/adjoint/DASolver/DAHisaFoam/DAHisaFoam.C
+++ b/src/adjoint/DASolver/DAHisaFoam/DAHisaFoam.C
@@ -189,16 +189,15 @@ label DAHisaFoam::solvePrimal()
         // print run time
         this->printElapsedTime(runTime, printToScreen_);
 
-        // if we want to use the function std as the convergence criteria, we need to compute the std
-        if (primalFuncStdTol_ > 0)
+        // if we want to use function std as the convergence criteria, compute the stds
+        if (this->usePrimalFuncStd())
         {
             this->calcFuncStd();
         }
-        if (funcStd_ < primalFuncStdTol_ && runTime.timeIndex() > primalMinIters_)
+        if (this->primalFuncStdConverged() && runTime.timeIndex() > primalMinIters_)
         {
 
-            Info << "Function " << primalFuncStdName_ << " std " << funcStd_ << " satisfied the prescribed tolerance " << primalFuncStdTol_ << endl
-                 << endl;
+            this->printPrimalFuncStdConverged();
             notFinished = false;
         }
 

--- a/src/adjoint/DASolver/DASolver.C
+++ b/src/adjoint/DASolver/DASolver.C
@@ -96,9 +96,63 @@ DASolver::DASolver(
     primalMinIters_ = daOptionPtr_->getOption<label>("primalMinIters");
     printInterval_ = daOptionPtr_->getOption<label>("printInterval");
     printIntervalUnsteady_ = daOptionPtr_->getOption<label>("printIntervalUnsteady");
-    primalFuncStdTol_ = daOptionPtr_->getSubDictOption<scalar>("primalFuncStdTol", "tol");
-    primalFuncStdName_ = daOptionPtr_->getSubDictOption<word>("primalFuncStdTol", "funcName");
-    primalFuncStdFrac_ = daOptionPtr_->getSubDictOption<scalar>("primalFuncStdTol", "nStepsFrac");
+    const dictionary& primalFuncStdTolDict = allOptions.subDict("primalFuncStdTol");
+    primalFuncStdTolDict.readIfPresent("tol", primalFuncStdTol_);
+    primalFuncStdTolDict.readIfPresent("funcName", primalFuncStdName_);
+    primalFuncStdTolDict.readIfPresent("nStepsFrac", primalFuncStdFrac_);
+    primalFuncStdTolDict.readIfPresent("funcNames", primalFuncStdNames_);
+    primalFuncStdTolDict.readIfPresent("tols", primalFuncStdTols_);
+
+    if (primalFuncStdNames_.empty() && primalFuncStdTol_ > 0)
+    {
+        primalFuncStdNames_.setSize(1);
+        primalFuncStdNames_[0] = primalFuncStdName_;
+    }
+
+    if (!primalFuncStdNames_.empty())
+    {
+        if (primalFuncStdTols_.empty() && primalFuncStdTol_ > 0)
+        {
+            primalFuncStdTols_.setSize(primalFuncStdNames_.size());
+            forAll(primalFuncStdTols_, idxI)
+            {
+                primalFuncStdTols_[idxI] = primalFuncStdTol_;
+            }
+        }
+        else if (primalFuncStdTols_.size() == 1 && primalFuncStdNames_.size() > 1)
+        {
+            scalar tol = primalFuncStdTols_[0];
+            primalFuncStdTols_.setSize(primalFuncStdNames_.size());
+            forAll(primalFuncStdTols_, idxI)
+            {
+                primalFuncStdTols_[idxI] = tol;
+            }
+        }
+
+        if (primalFuncStdTols_.size() != primalFuncStdNames_.size())
+        {
+            FatalErrorIn("DASolver") << "primalFuncStdTol funcNames and tols must have the same size. "
+                                     << "Got " << primalFuncStdNames_.size() << " funcNames and "
+                                     << primalFuncStdTols_.size() << " tols." << abort(FatalError);
+        }
+
+        forAll(primalFuncStdTols_, idxI)
+        {
+            if (primalFuncStdTols_[idxI] <= 0)
+            {
+                FatalErrorIn("DASolver") << "primalFuncStdTol tolerance for function "
+                                         << primalFuncStdNames_[idxI]
+                                         << " must be positive when funcNames is set."
+                                         << abort(FatalError);
+            }
+        }
+    }
+
+    funcStds_.setSize(primalFuncStdNames_.size());
+    forAll(funcStds_, idxI)
+    {
+        funcStds_[idxI] = 1e16;
+    }
 
     // if inputInto has unsteadyField, we need to initial GlobalVar::inputFieldUnsteady here
     this->initInputFieldUnsteady();
@@ -165,14 +219,14 @@ label DASolver::loop(Time& runTime)
         funcObj.execute();
     }
 
-    // if we want to use the function std as the convergence criteria, we need to compute the std
-    if (primalFuncStdTol_ > 0)
+    // if we want to use function std as the convergence criteria, compute the stds
+    if (this->usePrimalFuncStd())
     {
         this->calcFuncStd();
     }
 
-    // check exit condition, we need to satisfy both the residual and function std condition
-    if ((daGlobalVarPtr_->primalMaxRes < primalMinResTol_ || funcStd_ < primalFuncStdTol_) && runTime.timeIndex() > primalMinIters_)
+    // check exit condition
+    if ((daGlobalVarPtr_->primalMaxRes < primalMinResTol_ || this->primalFuncStdConverged()) && runTime.timeIndex() > primalMinIters_)
     {
         Info << "Time = " << t << endl;
 
@@ -181,10 +235,9 @@ label DASolver::loop(Time& runTime)
             Info << "Minimal residual " << daGlobalVarPtr_->primalMaxRes << " satisfied the prescribed tolerance " << primalMinResTol_ << endl
                  << endl;
         }
-        else if (funcStd_ < primalFuncStdTol_)
+        else if (this->primalFuncStdConverged())
         {
-            Info << "Function " << primalFuncStdName_ << " std " << funcStd_ << " satisfied the prescribed tolerance " << primalFuncStdTol_ << endl
-                 << endl;
+            this->printPrimalFuncStdConverged();
         }
 
         this->calcAllFunctions(1);
@@ -213,6 +266,42 @@ label DASolver::loop(Time& runTime)
     }
 }
 
+label DASolver::usePrimalFuncStd() const
+{
+    return primalFuncStdNames_.size() > 0;
+}
+
+label DASolver::primalFuncStdConverged() const
+{
+    if (!this->usePrimalFuncStd())
+    {
+        return 0;
+    }
+
+    forAll(funcStds_, idxI)
+    {
+        if (funcStds_[idxI] >= primalFuncStdTols_[idxI])
+        {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+void DASolver::printPrimalFuncStdConverged() const
+{
+    Info << "Function std convergence satisfied:" << endl;
+    forAll(primalFuncStdNames_, idxI)
+    {
+        Info << "    " << primalFuncStdNames_[idxI]
+             << " std " << funcStds_[idxI]
+             << " < tolerance " << primalFuncStdTols_[idxI]
+             << endl;
+    }
+    Info << endl;
+}
+
 void DASolver::calcFuncStd()
 {
     /*
@@ -221,29 +310,43 @@ void DASolver::calcFuncStd()
     */
     label timeIndex = runTimePtr_->timeIndex();
     label listIndex = timeIndex - 1;
-    label funcIdx = this->getFunctionListIndex(primalFuncStdName_);
+    if (listIndex < 0)
+    {
+        forAll(funcStds_, idxI)
+        {
+            funcStds_[idxI] = 1e16;
+        }
+        return;
+    }
+
     label window = max(2, round(primalFuncStdFrac_ * scalar(listIndex + 1)));
     label startIdx = max(0, listIndex - window + 1);
 
-    scalar mean = 0.0;
     label nActualSteps = listIndex - startIdx + 1;
-    for (label i = listIndex; i >= startIdx; i--)
+    forAll(primalFuncStdNames_, idxI)
     {
-        mean += functionTimeSteps_[funcIdx][i];
-    }
-    mean = mean / (nActualSteps + 1e-16);
+        label funcIdx = this->getFunctionListIndex(primalFuncStdNames_[idxI]);
 
-    funcStd_ = 0.0;
-    for (label i = listIndex; i >= startIdx; i--)
-    {
-        funcStd_ += (functionTimeSteps_[funcIdx][i] - mean) * (functionTimeSteps_[funcIdx][i] - mean);
+        scalar mean = 0.0;
+        for (label i = listIndex; i >= startIdx; i--)
+        {
+            mean += functionTimeSteps_[funcIdx][i];
+        }
+        mean = mean / (nActualSteps + 1e-16);
+
+        funcStds_[idxI] = 0.0;
+        for (label i = listIndex; i >= startIdx; i--)
+        {
+            funcStds_[idxI] += (functionTimeSteps_[funcIdx][i] - mean) * (functionTimeSteps_[funcIdx][i] - mean);
+        }
+        funcStds_[idxI] = funcStds_[idxI] / (nActualSteps + 1e-16);
+        funcStds_[idxI] = sqrt(funcStds_[idxI]) / mag(mean + 1e-16);
     }
-    funcStd_ = funcStd_ / (nActualSteps + 1e-16);
-    funcStd_ = sqrt(funcStd_) / mag(mean + 1e-16);
-    //Info << "funcTS " << functionTimeSteps_[funcIdx] << endl;
-    //Info << "mean " << mean << endl;
-    //Info << "nActualSteps " << nActualSteps << endl;
-    //Info << "funcStd " << funcStd_ << endl;
+
+    if (funcStds_.size() > 0)
+    {
+        funcStd_ = funcStds_[0];
+    }
 }
 
 void DASolver::calcAllFunctions(label print)
@@ -295,9 +398,13 @@ void DASolver::calcAllFunctions(label print)
             Info << functionName
                  << ": " << functionVal
                  << " " << timeOpType << ": " << timeOpVal;
-            if (primalFuncStdTol_ > 0 && functionName == primalFuncStdName_)
+            forAll(primalFuncStdNames_, stdI)
             {
-                Info << " std: " << funcStd_;
+                if (functionName == primalFuncStdNames_[stdI])
+                {
+                    Info << " std: " << funcStds_[stdI];
+                    break;
+                }
             }
 #ifdef CODI_ADF
             Info << " ADF-Deriv: " << timeOpVal.getGradient();
@@ -2640,8 +2747,7 @@ label DASolver::checkPrimalFailure()
     */
 
     // if the funcStd mode is used for convergence, we always return 0 without checking primalMinResTolDiff
-    scalar stdTol = daOptionPtr_->getSubDictOption<scalar>("primalFuncStdTol", "tol");
-    if (stdTol > 0)
+    if (this->usePrimalFuncStd())
     {
         return 0;
     }

--- a/src/adjoint/DASolver/DASolver.H
+++ b/src/adjoint/DASolver/DASolver.H
@@ -138,6 +138,15 @@ protected:
     /// write associated fields such as relative velocity
     void writeAssociatedFields();
 
+    /// return whether function std convergence is active
+    label usePrimalFuncStd() const;
+
+    /// return whether all monitored function stds satisfy their tolerances
+    label primalFuncStdConverged() const;
+
+    /// print monitored function std convergence information
+    void printPrimalFuncStdConverged() const;
+
     /// matrix-free dRdWT matrix used in GMRES solution
     Mat dRdWTMF_;
 
@@ -153,11 +162,20 @@ protected:
     /// the function name for the std tolerance
     word primalFuncStdName_ = "CD";
 
+    /// the function names for the std tolerance
+    wordList primalFuncStdNames_;
+
+    /// the function std tolerances
+    scalarList primalFuncStdTols_;
+
     /// the fraction of elapsed iterations to use as the std window
     scalar primalFuncStdFrac_ = 0.2;
 
     /// the std of a function, default to be -1
     scalar funcStd_ = 1e16;
+
+    /// the stds of functions monitored by primalFuncStdTol
+    scalarList funcStds_;
 
     /// whether to print primal information to the screen
     label printToScreen_ = 0;


### PR DESCRIPTION
## Summary

This extends the native DAFoam primal function-standard-deviation convergence check so it can monitor multiple functions at once. Existing single-function `primalFuncStdTol` usage remains supported through `tol` and `funcName`; users can now provide `funcNames` and `tols` to require all monitored function stds to satisfy their tolerances before stopping.

## Motivation

OpenFOAM `runTimeControl` can mutate the in-memory `Time` state through `writeAndEnd()`, which is unsafe for repeated primal evaluations inside optimization loops. A native DAFoam convergence path avoids relying on OpenFOAM function-object stop state and allows force-flat style checks such as requiring both `CD` and `CL` to flatten.

## Changes

- Add multi-function parsing for `primalFuncStdTol.funcNames` and `primalFuncStdTol.tols` with backward compatibility for `funcName`/`tol`.
- Compute and store one normalized std per monitored function.
- Require all monitored function std values to be below their tolerances before function-std convergence is declared.
- Apply the same convergence helper path to the DAHisaFoam primal loop.
- Document the new options in the Python defaults.

Example configuration:

```python
"primalFuncStdTol": {
    "funcNames": ["CD", "CL"],
    "tols": [1.0e-5, 1.0e-4],
    "nStepsFrac": 0.4,
}
```

## Validation

- `python3 -m py_compile dafoam/pyDAFoam.py`
- `git diff --check`

Attempted targeted C++ compile with the available `dafoam/opt-packages:v4.0.3` image, but current `main` fails before this patch on missing OpenFOAM writer headers (`vtkCoordSetWriter.H` / `coordSetWriter.H`) in `DACheckMesh`, so that image cannot compile this checkout cleanly.
