### PR TITLE
Fix the MassProp slice-count input name in DAFoamVSPVolume

### DIFF
--- a/dafoam/mphys/mphys_dafoam.py
+++ b/dafoam/mphys/mphys_dafoam.py
@@ -1993,7 +1993,7 @@ class DAFoamVSPVolume(ExplicitComponent):
             raise ValueError("slice_dir must be 'x', 'y', or 'z', got '%s'" % slice_dir)
         analysis_name = "MassProp"
         vsp.SetAnalysisInputDefaults(analysis_name)
-        vsp.SetIntAnalysisInput(analysis_name, "NumSlices", [n_slices])
+        vsp.SetIntAnalysisInput(analysis_name, "NumMassSlices", [n_slices])
         vsp.SetIntAnalysisInput(analysis_name, "MassSliceDir", [_dir_map[slice_dir.lower()]])
 
         shown_geom_ids = None


### PR DESCRIPTION
`DAFoamVSPVolume._run_massprop` sets the slice count with the analysis input name `NumSlices`. OpenVSP calls it `NumMassSlices`, so the call has never landed — every `compute` and every FD step of `compute_jacvec_product` logs

```
Error Code: 5, Desc: SetIntAnalysisInput::Can't Find Name NumSlices
```

and MassProp runs at whatever the default happens to be. The `n_slices` option is documented and accepted, but inert.

### Verification

Measured on a CST airfoil model, on **OpenVSP 3.42.3 and 3.51.0 alike** (the input name is the same in both):

| input name used | asked | effective `NumMassSlices` | volume |
|---|---|---|---|
| `NumSlices` (before) | 10 | 20 | 0.0008367507222 |
| `NumSlices` (before) | 50 | 20 | 0.0008367507222 |
| `NumSlices` (before) | 200 | 20 | 0.0008367507222 |
| `NumMassSlices` (after) | 10 | 10 | 0.0008418062515 |
| `NumMassSlices` (after) | 50 | 50 | 0.0008196022371 |

End to end, a `compute_totals` run of a CST airfoil case with `DAFoamVSPVolume(step=1e-6, relativeStep=False)` goes from 24 of those error lines per gradient evaluation to zero, and the adjoint completes as before.

### Note on behaviour

Existing cases will see their raw MassProp volume change, because the effective slice count moves from the default 20 to whatever they asked for. With the default `scaled=True` the constraint is normalised by the volume at the first design point, so the ratio is largely unaffected; what changes is that the requested resolution is now actually used.

One caveat worth knowing now that the option is live: on the model above, `NumMassSlices=200` exhausts memory and the process is killed — on both OpenVSP versions, so it is not a regression, but a large value is no longer silently ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)